### PR TITLE
Resolve SwiftLint warnings

### DIFF
--- a/SampleViewerUITests/SampleViewerUITests.swift
+++ b/SampleViewerUITests/SampleViewerUITests.swift
@@ -15,7 +15,8 @@ final class SampleViewerUITests: XCTestCase {
         // In UI tests it is usually best to stop immediately when a failure occurs.
         continueAfterFailure = false
 
-        // In UI tests it’s important to set the initial state - such as interface orientation - required for your tests before they run. The setUp method is a good place to do this.
+        // In UI tests it’s important to set the initial state - such as interface orientation -
+        // required for your tests before they run. The setUp method is a good place to do this.
     }
 
     override func tearDownWithError() throws {

--- a/SampleViewerUITests/SampleViewerUITestsLaunchTests.swift
+++ b/SampleViewerUITests/SampleViewerUITestsLaunchTests.swift
@@ -9,7 +9,7 @@ import XCTest
 
 final class SampleViewerUITestsLaunchTests: XCTestCase {
 
-    override class var runsForEachTargetApplicationUIConfiguration: Bool {
+    override static var runsForEachTargetApplicationUIConfiguration: Bool {
         true
     }
 


### PR DESCRIPTION
Closes #1

# Changes

This PR will resolve these SwiftLint warnings:

- SampleViewer/SampleViewerUITests/SampleViewerUITests.swift:18:1: warning: Line Length Violation: Line should be 120 characters or less; currently it has 182 characters (line_length)
- SampleViewer/SampleViewerUITests/SampleViewerUITestsLaunchTests.swift:12:5: warning: Static Over Final Class Violation: Prefer `static` over `class` in a final class (static_over_final_class)