### PR TITLE
Use Xcode 16.0 for GitHub Action test

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,5 +11,4 @@ jobs:
       - name: xcode-select
         run : sudo xcode-select -switch /Applications/Xcode_16.app/Contents/Developer
       - name: execute
-        run: xcodebuild test -testPlan SampleViewer -scheme SampleViewer -destination 'platform=iOS Simulator,name=iPhone 16 Pro Max'
-
+        run: xcodebuild test -skipPackagePluginValidation -testPlan SampleViewer -scheme SampleViewer -destination 'platform=iOS Simulator,name=iPhone 16 Pro Max'

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,6 +8,8 @@ jobs:
     runs-on: macOS-latest
     steps:
       - uses: actions/checkout@v4
-      - name: test
+      - name: xcode-select
+        run : sudo xcode-select -switch /Applications/Xcode_16.app/Contents/Developer
+      - name: execute
         run: xcodebuild test -testPlan SampleViewer -scheme SampleViewer -destination 'platform=iOS Simulator,name=iPhone 16 Pro Max'
 


### PR DESCRIPTION
Closes #3 

# Changes

This PR will

- make GitHub Action use Xcode 16.0.
- give a name to each step.
- insert `-skipPackagePluginValidation` option to skip SwiftLintBuildToolPlugin validation

https://github.com/S-Shimotori/SampleViewer/actions/runs/11320108808/job/31477139676

```
Validate plug-in “SwiftLintBuildToolPlugin” in package “swiftlint”
error: “SwiftLintBuildToolPlugin” must be enabled before it can be used
```