### PR TITLE
Add a target to refer constants

### DIFF
--- a/Package/Package.swift
+++ b/Package/Package.swift
@@ -10,6 +10,9 @@ let package = Package(
         .library(
             name: "SampleLibrary",
             targets: ["SampleLibrary"]),
+        .library(
+            name: "HIGConstants",
+            targets: ["HIGConstants"]),
     ],
     targets: [
         // Targets are the basic building blocks of a package, defining a module or a test suite.
@@ -20,5 +23,7 @@ let package = Package(
             name: "SampleLibraryTests",
             dependencies: ["SampleLibrary"]
         ),
+        .target(
+            name: "HIGConstants"),
     ]
 )

--- a/Package/Package.swift
+++ b/Package/Package.swift
@@ -25,5 +25,10 @@ let package = Package(
         ),
         .target(
             name: "HIGConstants"),
+        .target(
+            name: "Localization"),
+        .testTarget(
+            name: "LocalizationTests",
+            dependencies: ["Localization"]),
     ]
 )

--- a/Package/Sources/HIGConstants/HitTarget.swift
+++ b/Package/Sources/HIGConstants/HitTarget.swift
@@ -1,0 +1,12 @@
+import Foundation
+
+public enum HitTarget {
+    /// Minimum height of hit target.
+    ///
+    /// - SeeAlso: https://developer.apple.com/design/human-interface-guidelines/accessibility
+    public static let minimumHeight = CGFloat(44)
+    /// Minimum width of hit target.
+    ///
+    /// - SeeAlso: https://developer.apple.com/design/human-interface-guidelines/accessibility
+    public static let minimumWidth = CGFloat(44)
+}

--- a/Package/Sources/Localization/Locale.swift
+++ b/Package/Sources/Localization/Locale.swift
@@ -1,0 +1,6 @@
+import Foundation
+
+extension Locale {
+    public static let jaJP = Locale(identifier: "ja_JP")
+    public static let enUS = Locale(identifier: "en_US")
+}

--- a/Package/Sources/Localization/TimeZone.swift
+++ b/Package/Sources/Localization/TimeZone.swift
@@ -1,0 +1,6 @@
+import Foundation
+
+extension TimeZone {
+    public static let tokyo = TimeZone(identifier: "Asia/Tokyo")!
+    public static let losAngeles = TimeZone(identifier: "America/Los_Angeles")!
+}

--- a/Package/Tests/LocalizationTests/LocaleTest.swift
+++ b/Package/Tests/LocalizationTests/LocaleTest.swift
@@ -1,0 +1,15 @@
+import Foundation
+import Testing
+@testable import Localization
+
+struct LocaleTest {
+    @Test
+    func constants() async throws {
+        let locales: [Locale] = [
+            .jaJP,
+            .enUS,
+        ]
+        #expect(locales.allSatisfy { Locale.availableIdentifiers.contains($0.identifier) })
+    }
+
+}

--- a/Package/Tests/LocalizationTests/TimeZoneTest.swift
+++ b/Package/Tests/LocalizationTests/TimeZoneTest.swift
@@ -1,0 +1,14 @@
+import Foundation
+import Testing
+@testable import Localization
+
+struct TimeZoneTest {
+    @Test
+    func constants() async throws {
+        let timeZones: [TimeZone] = [
+            .tokyo,
+            .losAngeles,
+        ]
+        #expect(timeZones.allSatisfy { TimeZone.knownTimeZoneIdentifiers.contains($0.identifier) })
+    }
+}


### PR DESCRIPTION
Closes #6 

# Changes

This PR will add

- the list of constants mentioned in HIG
- the list of `TimeZone`
- the list of `Locale`

for logic and UI modules.