### PR TITLE
Add a sample view for HIG > Accessibility > Buttons and controls

### DIFF
--- a/Package/Package.swift
+++ b/Package/Package.swift
@@ -13,6 +13,9 @@ let package = Package(
         .library(
             name: "HIGConstants",
             targets: ["HIGConstants"]),
+        .library(
+            name: "Localization",
+            targets: ["Localization"]),
     ],
     targets: [
         // Targets are the basic building blocks of a package, defining a module or a test suite.

--- a/SampleViewer.xcodeproj/project.pbxproj
+++ b/SampleViewer.xcodeproj/project.pbxproj
@@ -8,6 +8,8 @@
 
 /* Begin PBXBuildFile section */
 		B5D10F902CBBCCCF007C807F /* SampleLibrary in Frameworks */ = {isa = PBXBuildFile; productRef = B5D10F8F2CBBCCCF007C807F /* SampleLibrary */; };
+		B5D226912CC2881500DF5561 /* HIGConstants in Frameworks */ = {isa = PBXBuildFile; productRef = B5D226902CC2881500DF5561 /* HIGConstants */; };
+		B5D226932CC2881500DF5561 /* Localization in Frameworks */ = {isa = PBXBuildFile; productRef = B5D226922CC2881500DF5561 /* Localization */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -57,6 +59,8 @@
 			buildActionMask = 2147483647;
 			files = (
 				B5D10F902CBBCCCF007C807F /* SampleLibrary in Frameworks */,
+				B5D226912CC2881500DF5561 /* HIGConstants in Frameworks */,
+				B5D226932CC2881500DF5561 /* Localization in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -127,6 +131,8 @@
 			name = SampleViewer;
 			packageProductDependencies = (
 				B5D10F8F2CBBCCCF007C807F /* SampleLibrary */,
+				B5D226902CC2881500DF5561 /* HIGConstants */,
+				B5D226922CC2881500DF5561 /* Localization */,
 			);
 			productName = SampleViewer;
 			productReference = B5DBB4392CBB8F9800A9A410 /* SampleViewer.app */;
@@ -361,6 +367,7 @@
 				ONLY_ACTIVE_ARCH = YES;
 				SDKROOT = iphoneos;
 				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "DEBUG $(inherited)";
+				SWIFT_EMIT_LOC_STRINGS = YES;
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
 			};
 			name = Debug;
@@ -417,6 +424,7 @@
 				MTL_FAST_MATH = YES;
 				SDKROOT = iphoneos;
 				SWIFT_COMPILATION_MODE = wholemodule;
+				SWIFT_EMIT_LOC_STRINGS = YES;
 				VALIDATE_PRODUCT = YES;
 			};
 			name = Release;
@@ -629,6 +637,16 @@
 		B5D10F8F2CBBCCCF007C807F /* SampleLibrary */ = {
 			isa = XCSwiftPackageProductDependency;
 			productName = SampleLibrary;
+		};
+		B5D226902CC2881500DF5561 /* HIGConstants */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = B5D10F8C2CBBCC5F007C807F /* XCLocalSwiftPackageReference "Package" */;
+			productName = HIGConstants;
+		};
+		B5D226922CC2881500DF5561 /* Localization */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = B5D10F8C2CBBCC5F007C807F /* XCLocalSwiftPackageReference "Package" */;
+			productName = Localization;
 		};
 /* End XCSwiftPackageProductDependency section */
 	};

--- a/SampleViewer/Dependency/DateProvider.swift
+++ b/SampleViewer/Dependency/DateProvider.swift
@@ -1,0 +1,17 @@
+import Foundation
+
+// MARK: - DateProviderProtocol
+
+protocol DateProviderProtocol {
+    var now: Date { get }
+}
+
+// MARK: - DateProvider
+
+struct DateProvider {}
+
+extension DateProvider: DateProviderProtocol {
+    var now: Date {
+        Date.now
+    }
+}

--- a/SampleViewer/Localizable.xcstrings
+++ b/SampleViewer/Localizable.xcstrings
@@ -1,0 +1,57 @@
+{
+  "sourceLanguage" : "en",
+  "strings" : {
+    "hig.accessibility.controls.size.button.caption" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Last tapped"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "最後にタップした日時"
+          }
+        }
+      }
+    },
+    "hig.accessibility.controls.size.description" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "On touchscreen devices, a hit target needs to measure at least 44x44 pt."
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "タッチスクリーンデバイスでは、ヒットターゲットの大きさが44x44ポイント以上である必要があります。"
+          }
+        }
+      }
+    },
+    "hig.accessibility.controls.size.title" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Size of Hit Target"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "ヒットターゲットの大きさ"
+          }
+        }
+      }
+    }
+  },
+  "version" : "1.0"
+}

--- a/SampleViewer/View/HitTargetView.swift
+++ b/SampleViewer/View/HitTargetView.swift
@@ -1,0 +1,84 @@
+import SwiftUI
+import HIGConstants
+import Localization
+
+struct HitTargetView: View {
+    private let dateProvider: any DateProviderProtocol
+
+    @Environment(\.timeZone)
+    private var timeZone: TimeZone
+
+    @Environment(\.locale)
+    private var locale: Locale
+
+    @State
+    private var timestamp: Date?
+
+    init(dateProvider: some DateProviderProtocol) {
+        self.dateProvider = dateProvider
+    }
+
+    var body: some View {
+        VStack {
+            Text("hig.accessibility.controls.size.title")
+                .font(.title)
+            Text("hig.accessibility.controls.size.description")
+                .font(.body)
+
+            Button {
+                timestamp = dateProvider.now
+            } label: {
+                Image(systemName: "hand.thumbsup.fill")
+            }
+            .frame(
+                width: HitTarget.minimumWidth,
+                height: HitTarget.minimumHeight
+            )
+            .foregroundStyle(.white)
+            .background(.blue)
+
+            (
+                Text("hig.accessibility.controls.size.button.caption")
+                + Text(verbatim: " : ")
+                + Text(verbatim: timestamp.map { formatted($0) } ?? "---")
+            )
+            .font(.caption)
+        }
+    }
+
+    private func formatted(_ date: Date) -> String {
+        var formatStyle = Date.FormatStyle.dateTime
+            .year()
+            .month()
+            .day()
+            .hour()
+            .minute()
+            .second()
+            .locale(locale)
+        formatStyle.timeZone = timeZone
+        return date.formatted(formatStyle)
+    }
+}
+
+// MARK: - Xcode Preview
+
+#Preview {
+    HitTargetView(
+        dateProvider: StubDateProvider()
+    )
+    .environment(\.timeZone, .losAngeles)
+    .environment(\.locale, .enUS)
+}
+
+#Preview {
+    HitTargetView(
+        dateProvider: StubDateProvider()
+    )
+    .environment(\.timeZone, .tokyo)
+    .environment(\.locale, .jaJP)
+}
+
+private struct StubDateProvider: DateProviderProtocol {
+    // 2014-10-15T09:30:45+09:00
+    let now = Date(timeIntervalSince1970: 1728952245)
+}


### PR DESCRIPTION
Closes #5 

# Changes

This PR will add 

- DateProvider.swift to inject `Date.now`
- Localizable.xcstrings to show text
- HitTargetView.swift to check size of hit target

# Screenshots

|America/LosAngeles, en_US|Asia/Tokyo, ja_JP|
|---|---|
|<img src=https://github.com/user-attachments/assets/88e6bbd3-dde8-4066-aaa8-08d3089531ec width=200>|<img src=https://github.com/user-attachments/assets/4d2f4c9d-0982-48ec-b35a-2b6eb1756b66 width=200>|