### PR TITLE
Add .swiftlint.yml

### DIFF
--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -1,0 +1,75 @@
+# By default, SwiftLint uses a set of sensible default rules you can adjust:
+disabled_rules: # rule identifiers turned on by default to exclude from running
+  - colon
+  - comma
+  - control_statement
+opt_in_rules: # some rules are turned off by default, so you need to opt-in
+  - empty_count # find all the available rules by running: `swiftlint rules`
+
+# Alternatively, specify all rules explicitly by uncommenting this option:
+# only_rules: # delete `disabled_rules` & `opt_in_rules` if using this
+#   - empty_parameters
+#   - vertical_whitespace
+
+analyzer_rules: # rules run by `swiftlint analyze`
+  - explicit_self
+
+# Case-sensitive paths to include during linting. Directory paths supplied on the
+# command line will be ignored.
+included:
+  - Sources
+excluded: # case-sensitive paths to ignore during linting. Takes precedence over `included`
+  - Carthage
+  - Pods
+  - Sources/ExcludedFolder
+  - Sources/ExcludedFile.swift
+  - Sources/*/ExcludedFile.swift # exclude files with a wildcard
+
+# If true, SwiftLint will not fail if no lintable files are found.
+allow_zero_lintable_files: false
+
+# If true, SwiftLint will treat all warnings as errors.
+strict: false
+
+# The path to a baseline file, which will be used to filter out detected violations.
+baseline: Baseline.json
+
+# The path to save detected violations to as a new baseline.
+write_baseline: Baseline.json
+
+# If true, SwiftLint will check for updates after linting or analyzing.
+check_for_updates: true
+
+# configurable rules can be customized from this configuration file
+# binary rules can set their severity level
+force_cast: warning # implicitly
+force_try:
+  severity: warning # explicitly
+# rules that have both warning and error levels, can set just the warning level
+# implicitly
+line_length: 110
+# they can set both implicitly with an array
+type_body_length:
+  - 300 # warning
+  - 400 # error
+# or they can set both explicitly
+file_length:
+  warning: 500
+  error: 1200
+# naming rules can set warnings/errors for min_length and max_length
+# additionally they can set excluded names
+type_name:
+  min_length: 4 # only warning
+  max_length: # warning and error
+    warning: 40
+    error: 50
+  excluded: iPhone # excluded via string
+  allowed_symbols: ["_"] # these are allowed in type names
+identifier_name:
+  min_length: # only min_length
+    error: 4 # only error
+  excluded: # excluded via string array
+    - id
+    - URL
+    - GlobalAPIKey
+reporter: "xcode" # reporter type (xcode, json, csv, checkstyle, codeclimate, junit, html, emoji, sonarqube, markdown, github-actions-logging, summary)

--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -1,8 +1,6 @@
 # By default, SwiftLint uses a set of sensible default rules you can adjust:
 disabled_rules: # rule identifiers turned on by default to exclude from running
-  - colon
-  - comma
-  - control_statement
+  - trailing_comma
 opt_in_rules: # some rules are turned off by default, so you need to opt-in
   - empty_count # find all the available rules by running: `swiftlint rules`
 
@@ -17,13 +15,13 @@ analyzer_rules: # rules run by `swiftlint analyze`
 # Case-sensitive paths to include during linting. Directory paths supplied on the
 # command line will be ignored.
 included:
-  - Sources
+  - Package
+  - SampleViewer
+  - SampleViewerTests
+  - SampleViewerUITests
 excluded: # case-sensitive paths to ignore during linting. Takes precedence over `included`
   - Carthage
   - Pods
-  - Sources/ExcludedFolder
-  - Sources/ExcludedFile.swift
-  - Sources/*/ExcludedFile.swift # exclude files with a wildcard
 
 # If true, SwiftLint will not fail if no lintable files are found.
 allow_zero_lintable_files: false
@@ -32,10 +30,10 @@ allow_zero_lintable_files: false
 strict: false
 
 # The path to a baseline file, which will be used to filter out detected violations.
-baseline: Baseline.json
+# baseline: Baseline.json
 
 # The path to save detected violations to as a new baseline.
-write_baseline: Baseline.json
+# write_baseline: Baseline.json
 
 # If true, SwiftLint will check for updates after linting or analyzing.
 check_for_updates: true
@@ -67,7 +65,7 @@ type_name:
   allowed_symbols: ["_"] # these are allowed in type names
 identifier_name:
   min_length: # only min_length
-    error: 4 # only error
+    error: 2 # only error
   excluded: # excluded via string array
     - id
     - URL


### PR DESCRIPTION
Closes #9

# Changes

- .swiftlint.yml
    - Template: https://github.com/realm/SwiftLint
    - Disable `trailing_comma`: To suppress unnecessary commit logs
    - `identifier_name` > `min_length` > `error: 2`: The length of some standard identifier names are only 3.