### PR TITLE
Disable `todo` swiftlint rule

### DIFF
--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -1,6 +1,7 @@
 # By default, SwiftLint uses a set of sensible default rules you can adjust:
 disabled_rules: # rule identifiers turned on by default to exclude from running
   - trailing_comma
+  - todo
 opt_in_rules: # some rules are turned off by default, so you need to opt-in
   - empty_count # find all the available rules by running: `swiftlint rules`
 


### PR DESCRIPTION
Closes #36

# Changes

- .swiftlint.yml
    - Disable `todo` rule