### PR TITLE
Add a sample view for button styles

### DIFF
--- a/SampleViewer/Localizable.xcstrings
+++ b/SampleViewer/Localizable.xcstrings
@@ -1,6 +1,74 @@
 {
   "sourceLanguage" : "en",
   "strings" : {
+    "hig.accessibility.controls.configuration.description" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "You can use the visually prominent filled style for the button that performs the most likely action in a view, using less prominent styles — such as gray or plain — for buttons that perform less important actions."
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "ビューで頻繁に実行されるアクションのボタンに塗りつぶしスタイルを適用して目立たせ、重要性の低いアクションのボタンには目立たないグレイや標準のスタイルを適用できます。"
+          }
+        }
+      }
+    },
+    "hig.accessibility.controls.configuration.section.swiftui" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "SwiftUI"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "SwiftUI"
+          }
+        }
+      }
+    },
+    "hig.accessibility.controls.configuration.section.uikit" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "UIKit"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "UIKit"
+          }
+        }
+      }
+    },
+    "hig.accessibility.controls.configuration.title" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Relative Importance of Buttons"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "ボタンの相対的重要性"
+          }
+        }
+      }
+    },
     "hig.accessibility.controls.size.button.caption" : {
       "extractionState" : "manual",
       "localizations" : {

--- a/SampleViewer/View/RelativeImportanceView.swift
+++ b/SampleViewer/View/RelativeImportanceView.swift
@@ -1,0 +1,165 @@
+import SwiftUI
+import Localization
+
+struct RelativeImportanceView: View {
+    var body: some View {
+        ScrollView {
+            VStack {
+                Text("hig.accessibility.controls.configuration.title")
+                    .font(.title)
+                Text("hig.accessibility.controls.configuration.description")
+                    .font(.body)
+            }
+
+            GroupBox(
+                label: Label(
+                    "hig.accessibility.controls.configuration.section.swiftui",
+                    systemImage: "swift"
+                )
+            ) {
+                VStack {
+                    // TODO: Refactor
+                    // We cannot create an array for `buttonStyle<S>(_:)`
+                    // because there are different types of button style protocols.
+
+                    Button {
+                    } label: {
+                        Text(verbatim: "PrimitiveButtonStyle.plain")
+                            .frame(maxWidth: .infinity, maxHeight: Layout.heightOfButton)
+                    }
+                    .buttonStyle(.plain)
+
+                    Button {
+                    } label: {
+                        Text(verbatim: "PrimitiveButtonStyle.automatic")
+                            .frame(maxWidth: .infinity, maxHeight: Layout.heightOfButton)
+                    }
+                    .buttonStyle(.automatic)
+
+                    Button {
+                    } label: {
+                        Text(verbatim: "PrimitiveButtonStyle.bordered")
+                            .frame(maxWidth: .infinity, maxHeight: Layout.heightOfButton)
+                    }
+                    .buttonStyle(.bordered)
+
+                    Button {
+                    } label: {
+                        Text(verbatim: "PrimitiveButtonStyle.borderedProminent")
+                            .frame(maxWidth: .infinity, maxHeight: Layout.heightOfButton)
+                    }
+                    .buttonStyle(.borderedProminent)
+
+                    Button {
+                    } label: {
+                        Text(verbatim: "PrimitiveButtonStyle.borderless")
+                            .frame(maxWidth: .infinity, maxHeight: Layout.heightOfButton)
+                    }
+                    .buttonStyle(.borderless)
+                }
+                .padding()
+            }
+
+            GroupBox(
+                label: Label(
+                    "hig.accessibility.controls.configuration.section.uikit",
+                    systemImage: "square.stack.3d.up"
+                )
+            ) {
+                VStack {
+                    ForEach(RelativeImportanceView.uiKitButtonConfigurations, id: \.id) {
+                        ConfiguredUIKitButton(configuration: $0.configuration)
+                            .frame(maxWidth: .infinity, maxHeight: Layout.heightOfButton)
+                    }
+                }
+            }
+        }
+    }
+}
+
+extension RelativeImportanceView {
+    private enum Layout {
+        static let heightOfButton = CGFloat(50)
+    }
+
+    private struct UIKitButtonConfiguration {
+        let id = UUID()
+        let configuration: UIButton.Configuration
+    }
+
+    private static let uiKitButtonConfigurations: [UIKitButtonConfiguration] = [
+        .init(configuration: {
+            var configuration = UIButton.Configuration.plain()
+            configuration.title = "UIButton.Configuration.plain"
+            return configuration
+        }()),
+        .init(configuration: {
+            var configuration = UIButton.Configuration.gray()
+            configuration.title = "UIButton.Configuration.gray"
+            return configuration
+        }()),
+        .init(configuration: {
+            var configuration = UIButton.Configuration.tinted()
+            configuration.title = "UIButton.Configuration.tinted"
+            return configuration
+        }()),
+        .init(configuration: {
+            var configuration = UIButton.Configuration.filled()
+            configuration.title = "UIButton.Configuration.filled"
+            return configuration
+        }()),
+        .init(configuration: {
+            var configuration = UIButton.Configuration.borderless()
+            configuration.title = "UIButton.Configuration.borderless"
+            return configuration
+        }()),
+        .init(configuration: {
+            var configuration = UIButton.Configuration.bordered()
+            configuration.title = "UIButton.Configuration.bordered"
+            return configuration
+        }()),
+        .init(configuration: {
+            var configuration = UIButton.Configuration.borderedTinted()
+            configuration.title = "UIButton.Configuration.borderedTinted"
+            return configuration
+        }()),
+        .init(configuration: {
+            var configuration = UIButton.Configuration.borderedProminent()
+            configuration.title = "UIButton.Configuration.borderedProminent"
+            return configuration
+        }()),
+    ]
+
+}
+
+// MARK: - ConfiguredUIButton
+
+private struct ConfiguredUIKitButton {
+    private let configuration: UIButton.Configuration
+
+    init(
+        configuration: UIButton.Configuration
+    ) {
+        self.configuration = configuration
+    }
+}
+
+extension ConfiguredUIKitButton: UIViewRepresentable {
+    func makeUIView(context: Context) -> UIButton {
+        UIButton(configuration: configuration)
+    }
+
+    func updateUIView(_ uiView: UIButton, context: Context) {}
+}
+
+// MARK: - Xcode Preview
+
+#Preview("RelativeImportanceView(locale=enUS)") {
+    RelativeImportanceView()
+        .environment(\.locale, .enUS)
+}
+
+#Preview("RelativeImportanceView(locale=jaJP)") {
+    RelativeImportanceView()
+        .environment(\.locale, .jaJP)
+}


### PR DESCRIPTION
Closes #12 

# Changes

- SampleViewer/Localizable.xcstrings
    - Add localized strings for the sample
- SampleViewer/View/RelativeImportanceView.swift
    - Add the sample

# Screenshots

|`enUS`|`jaJP`|
|---|---|
|<img src=https://github.com/user-attachments/assets/c0f162dc-ee4b-41e4-9733-f9950c8f8c6b width=200>|<img src=https://github.com/user-attachments/assets/35a3c7ad-06d9-4fba-9956-14744218bec1 width=200>|