### PR TITLE
Add a sample view for an alternate way to an action

### DIFF
--- a/SampleViewer/Localizable.xcstrings
+++ b/SampleViewer/Localizable.xcstrings
@@ -119,6 +119,142 @@
           }
         }
       }
+    },
+    "hig.accessibility.gestures.alternative.description" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Include an option for people who may not be able to perform a specific gesture."
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "特定のジェスチャができないユーザ向けのオプションを含めます。"
+          }
+        }
+      }
+    },
+    "hig.accessibility.gestures.alternative.title" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Alternative Ways to Perform Gesture-based Actions"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "ジェスチャベースのアクションを実行するための代替手段"
+          }
+        }
+      }
+    },
+    "sample.description" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Description"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "説明文"
+          }
+        }
+      }
+    },
+    "sample.detail" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Detail"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "詳細"
+          }
+        }
+      }
+    },
+    "sample.navigation.title" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Navigation Title"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "ナビゲーションタイトル"
+          }
+        }
+      }
+    },
+    "sample.section.title" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Section Title"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "セクションタイトル"
+          }
+        }
+      }
+    },
+    "sample.subtitle" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Subtitle"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "サブタイトル"
+          }
+        }
+      }
+    },
+    "sample.title" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Title"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "タイトル"
+          }
+        }
+      }
     }
   },
   "version" : "1.0"

--- a/SampleViewer/View/GestureBasedActionView.swift
+++ b/SampleViewer/View/GestureBasedActionView.swift
@@ -1,0 +1,84 @@
+import SwiftUI
+
+struct GestureBasedActionView: View {
+    @Environment(\.editMode) private var editMode
+    @Environment(\.locale) private var locale
+
+    @State private var items = Array(repeating: SampleItem(id: UUID()), count: 5)
+
+    var body: some View {
+        NavigationView {
+            Form {
+                Section {
+                    VStack {
+                        Text("hig.accessibility.gestures.alternative.title")
+                            .font(.title)
+                        Text("hig.accessibility.gestures.alternative.description")
+                            .font(.body)
+                    }
+                }
+                Section {
+                    ForEach(items) { _ in
+                        SampleItemView()
+                    }
+                    .onDelete { indexSet in
+                        items.remove(atOffsets: indexSet)
+                    }
+                } header: {
+                    Text("sample.section.title")
+                }
+            }
+            .animation(nil, value: editMode?.wrappedValue)
+            .toolbar {
+                EditButton()
+            }
+            .navigationBarTitleDisplayMode(.inline)
+            .navigationTitle("sample.navigation.title")
+        }
+    }
+}
+
+// MARK: - SampleItem
+
+private struct SampleItem {
+    var id: UUID
+}
+
+extension SampleItem: Identifiable {}
+
+private struct SampleItemView: View {
+    var body: some View {
+        HStack {
+            Color.gray // instead of `AsyncImage`
+                .scaledToFit()
+                .frame(width: 35, height: 35)
+                .clipShape(RoundedRectangle(cornerRadius: 5))
+            VStack(alignment: .leading) {
+                Text("sample.title")
+                    .font(.body)
+                Text("sample.subtitle")
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+            }
+            Spacer()
+            Text("sample.detail")
+                .foregroundStyle(.secondary)
+        }
+    }
+}
+
+// MARK: - Xcode Preview
+
+#Preview("GestureBasedActionView(locale=enUS)") {
+    GestureBasedActionView()
+        .environment(\.locale, .enUS)
+}
+
+#Preview("GestureBasedActionView(locale=jaJP)") {
+    GestureBasedActionView()
+        .environment(\.locale, .jaJP)
+}
+
+#Preview("SampleItemView") {
+    SampleItemView()
+}


### PR DESCRIPTION
Closes #11 

# Changes

- SampleViewer/Localizable.xcstrings
    - Add text on the sample view
- SampleViewer/View/GestureBasedActionView.swift
    - Add the sample

# Screenshots

||`enUS`|`jaJP`|
|---|---|---|
|Gesture-based|<img src=https://github.com/user-attachments/assets/2d9cb1fb-395d-42ab-9223-bb65fd5ab5be width=200>|<img src=https://github.com/user-attachments/assets/1c85166d-2804-477e-b442-86b3ad800480 width=200>|
|Alternate way|<img src=https://github.com/user-attachments/assets/3c285109-0df4-466d-9498-ad1fa9c3466f width=200>|<img src=https://github.com/user-attachments/assets/eca93736-d7af-4cc4-888e-d3dcc9e25fc8 width=200>|