### PR TITLE
Add a sample view for system colors

### DIFF
--- a/SampleViewer/Assets.xcassets/Sample Colors/Contents.json
+++ b/SampleViewer/Assets.xcassets/Sample Colors/Contents.json
@@ -1,0 +1,6 @@
+{
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/SampleViewer/Assets.xcassets/Sample Colors/dark-mode.colors.background.colorset/Contents.json
+++ b/SampleViewer/Assets.xcassets/Sample Colors/dark-mode.colors.background.colorset/Contents.json
@@ -1,0 +1,38 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0xF2",
+          "green" : "0xF2",
+          "red" : "0xF2"
+        }
+      },
+      "idiom" : "universal"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "dark"
+        }
+      ],
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0x33",
+          "green" : "0x33",
+          "red" : "0x33"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/SampleViewer/Localizable.xcstrings
+++ b/SampleViewer/Localizable.xcstrings
@@ -273,6 +273,74 @@
         }
       }
     },
+    "hig.dark-mode.colors.dark.title" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "System colors in the dark appearance"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "ダークな外観でのシステムカラー"
+          }
+        }
+      }
+    },
+    "hig.dark-mode.colors.description" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Semantic colors (like labelColor and controlColor in macOS or separator in iOS and iPadOS) automatically adapt to the current appearance."
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "セマンティックカラー（macOSのlabelColorやcontrolColor、iOSとiPadOSのseparatorなど）は、自動的に現在の外観に適応します。"
+          }
+        }
+      }
+    },
+    "hig.dark-mode.colors.light.title" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "System colors in the light appearance"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "ライトな外観でのシステムカラー"
+          }
+        }
+      }
+    },
+    "hig.dark-mode.colors.title" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Colors"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "カラー"
+          }
+        }
+      }
+    },
     "sample.description" : {
       "extractionState" : "manual",
       "localizations" : {

--- a/SampleViewer/View/SystemColorView.swift
+++ b/SampleViewer/View/SystemColorView.swift
@@ -1,0 +1,78 @@
+import SwiftUI
+
+struct SystemColorView: View {
+    private let cornerRadius = CGFloat(5)
+
+    private let appearanceBoxes = [
+        AppearanceBox(
+            id: UUID(),
+            titleKey: "hig.dark-mode.colors.light.title",
+            colorScheme: .light
+        ),
+        AppearanceBox(
+            id: UUID(),
+            titleKey: "hig.dark-mode.colors.dark.title",
+            colorScheme: .dark
+        ),
+    ]
+
+    var body: some View {
+        VStack {
+            VStack {
+                Text("hig.dark-mode.colors.title")
+                    .font(.title)
+                Text("hig.dark-mode.colors.description")
+                    .font(.body)
+            }
+
+            ForEach(appearanceBoxes) { appearanceBox in
+                GroupBox(appearanceBox.titleKey) {
+                    Grid {
+                        GridRow {
+                            RoundedRectangle(cornerRadius: cornerRadius)
+                                .fill(Color.blue)
+                            RoundedRectangle(cornerRadius: cornerRadius)
+                                .fill(Color.green)
+                        }
+                        GridRow {
+                            RoundedRectangle(cornerRadius: cornerRadius)
+                                .fill(Color.indigo)
+                            RoundedRectangle(cornerRadius: cornerRadius)
+                                .fill(Color.purple)
+                        }
+                    }
+                }
+                .backgroundStyle(Color("dark-mode.colors.background"))
+                .environment(\.colorScheme, appearanceBox.colorScheme)
+            }
+        }.padding()
+    }
+}
+
+// MARK: - AppearanceBox
+
+private struct AppearanceBox: Identifiable {
+    var id: UUID
+    var titleKey: LocalizedStringKey
+    var colorScheme: ColorScheme
+}
+
+// MARK: - Xcode Preview
+
+#Preview("SystemColorView(locale=enUS,colorScheme=light)") {
+    SystemColorView()
+        .environment(\.locale, .enUS)
+        .environment(\.colorScheme, .light)
+}
+
+#Preview("SystemColorView(locale=jaJP,colorScheme=light)") {
+    SystemColorView()
+        .environment(\.locale, .jaJP)
+        .environment(\.colorScheme, .light)
+}
+
+#Preview("SystemColorView(locale=enUS,colorScheme=dark)") {
+    SystemColorView()
+        .environment(\.locale, .enUS)
+        .environment(\.colorScheme, .dark)
+}


### PR DESCRIPTION
Closes #16 

# Changes

- SampleViewer/Assets.xcassets/Sample Colors
    - Add a background color
- SampleViewer/Localizable.xcstrings
    - Add a description of the sample
- SampleViewer/View/SystemColorView.swift
    - Add the sample

# Screenshots

|enUS|jaJP|
|---|---|
|<img src=https://github.com/user-attachments/assets/1000230e-910d-4c98-a1c6-9ee82914f561 width=200>|<img src=https://github.com/user-attachments/assets/80c5279b-2e6f-44e2-959c-2b6d8edf8857 width=200>|