### PR TITLE
Add a sample view for system label colors

### DIFF
--- a/SampleViewer/Assets.xcassets/Sample Colors/dark-mode.labels.background.colorset/Contents.json
+++ b/SampleViewer/Assets.xcassets/Sample Colors/dark-mode.labels.background.colorset/Contents.json
@@ -1,0 +1,38 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0xFF",
+          "green" : "0xFF",
+          "red" : "0xFF"
+        }
+      },
+      "idiom" : "universal"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "dark"
+        }
+      ],
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0x00",
+          "green" : "0x00",
+          "red" : "0x00"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/SampleViewer/Localizable.xcstrings
+++ b/SampleViewer/Localizable.xcstrings
@@ -341,6 +341,74 @@
         }
       }
     },
+    "hig.dark-mode.labels.dark.title" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Labels in the dark appearance"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "ダークな外観でのラベル"
+          }
+        }
+      }
+    },
+    "hig.dark-mode.labels.description" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "The primary, secondary, tertiary, and quaternary label colors adapt automatically to the light and dark appearances."
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "第1、第2、第3、第4のラベルカラーは、ライトとダークの外観に自動的に適応します。"
+          }
+        }
+      }
+    },
+    "hig.dark-mode.labels.light.title" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Labels in the light appearance"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "ライトな外観でのラベル"
+          }
+        }
+      }
+    },
+    "hig.dark-mode.labels.title" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Labels"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "ラベル"
+          }
+        }
+      }
+    },
     "sample.description" : {
       "extractionState" : "manual",
       "localizations" : {
@@ -371,6 +439,23 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "詳細"
+          }
+        }
+      }
+    },
+    "sample.label" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Label"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "ラベル"
           }
         }
       }

--- a/SampleViewer/View/SystemLabelView.swift
+++ b/SampleViewer/View/SystemLabelView.swift
@@ -1,0 +1,73 @@
+import SwiftUI
+
+struct SystemLabelView: View {
+    private let appearanceBoxes = [
+        AppearanceBox(
+            id: UUID(),
+            titleKey: "hig.dark-mode.labels.light.title",
+            colorScheme: .light
+        ),
+        AppearanceBox(
+            id: UUID(),
+            titleKey: "hig.dark-mode.labels.dark.title",
+            colorScheme: .dark
+        ),
+    ]
+
+    var body: some View {
+        VStack {
+            VStack {
+                Text("hig.dark-mode.labels.title")
+                    .font(.title)
+                Text("hig.dark-mode.labels.description")
+                    .font(.body)
+            }
+
+            ForEach(appearanceBoxes) { appearanceBox in
+                GroupBox(appearanceBox.titleKey) {
+                    VStack {
+                        Text("sample.label")
+                            .foregroundStyle(Color.primary)
+                        Text("sample.label")
+                            .foregroundStyle(Color.secondary)
+                    }
+                    .padding()
+                }
+                .backgroundStyle(Color("dark-mode.labels.background"))
+                .environment(\.colorScheme, appearanceBox.colorScheme)
+            }
+        }.padding()
+    }
+}
+
+// MARK: - AppearanceBox
+
+private struct AppearanceBox: Identifiable {
+    var id: UUID
+    var titleKey: LocalizedStringKey
+    var colorScheme: ColorScheme
+}
+
+#Preview {
+    SystemLabelView()
+}
+
+// MARK: - Xcode Preview
+
+#Preview("SystemLabelView(locale=enUS,colorScheme=light)") {
+    SystemLabelView()
+        .environment(\.locale, .enUS)
+        .environment(\.colorScheme, .light)
+}
+
+#Preview("SystemLabelView(locale=jaJP,colorScheme=light)") {
+    SystemLabelView()
+        .environment(\.locale, .jaJP)
+        .environment(\.colorScheme, .light)
+}
+
+#Preview("SystemLabelView(locale=enUS,colorScheme=dark)") {
+    SystemLabelView()
+        .environment(\.locale, .enUS)
+        .environment(\.colorScheme, .dark)
+}


### PR DESCRIPTION
Closes #17 

# Changes

- SampleViewer/Assets.xcassets/Sample Colors/dark-mode.labels.background.colorset/Contents.json
    - Add a background color for sample view
- SampleViewer/Localizable.xcstrings
    - Add description texts and sample text
- SampleViewer/View/SystemLabelView.swift
    - Add the sample

# Screenshots

|enUS|jaJP|
|---|---|
|<img src=https://github.com/user-attachments/assets/4c632854-53ba-4d0e-8ddd-601765b5b671 width=200>|<img src=https://github.com/user-attachments/assets/43e7030b-4ff4-455c-b8a6-a48a46a68c42 width=200>|