### PR TITLE
Add a sample view for vibrancy

### DIFF
--- a/SampleViewer/Localizable.xcstrings
+++ b/SampleViewer/Localizable.xcstrings
@@ -443,6 +443,125 @@
         }
       }
     },
+    "hig.materials.ios.vibrancy.defaultLabel.description" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Default label on regular material"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "regularマテリアルでのデフォルトラベル"
+          }
+        }
+      }
+    },
+    "hig.materials.ios.vibrancy.label.description" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Except for quaternary, you can use the following vibrancy values for labels on any material. In general, avoid using quaternary on top of the thin and ultraThin materials, because the contrast is too low."
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "4段階目のquaternaryLabelを除き、あらゆるマテリアルのラベルには次のバイブランス値を使用できます。一般的に、thinおよびultraThinの上では、コントラストが低すぎるため、4段階目の使用は避けてください。"
+          }
+        }
+      }
+    },
+    "hig.materials.ios.vibrancy.quaternaryLabel.description" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Quaternary label on regular material"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "regularマテリアルでの第4ラベル"
+          }
+        }
+      }
+    },
+    "hig.materials.ios.vibrancy.secondaryLabel.description" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Secondary label on regular material"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "regularマテリアルでの第2ラベル"
+          }
+        }
+      }
+    },
+    "hig.materials.ios.vibrancy.separator.description" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Labels and fills both have several levels of vibrancy; separators have one level."
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "ラベルと塗りつぶしにはどちらも複数のレベルのバイブランスがありますが、区切りには1つのレベルしかありません。"
+          }
+        }
+      }
+    },
+    "hig.materials.ios.vibrancy.tertiaryLabel.description" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Tertiary label on regular material"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "regularマテリアルでの第3ラベル"
+          }
+        }
+      }
+    },
+    "hig.materials.ios.vibrancy.title" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Vibrancy"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "バイブランス"
+          }
+        }
+      }
+    },
     "sample.description" : {
       "extractionState" : "manual",
       "localizations" : {

--- a/SampleViewer/View/VibrancyView.swift
+++ b/SampleViewer/View/VibrancyView.swift
@@ -1,0 +1,174 @@
+import SwiftUI
+
+struct VibrancyView: View {
+    private let labelVibrancies = [
+        LabelVibrancy(
+            id: UUID(),
+            vibrancyEffectStyle: .label,
+            description: "hig.materials.ios.vibrancy.defaultLabel.description"
+        ),
+        LabelVibrancy(
+            id: UUID(),
+            vibrancyEffectStyle: .secondaryLabel,
+            description: "hig.materials.ios.vibrancy.secondaryLabel.description"
+        ),
+        LabelVibrancy(
+            id: UUID(),
+            vibrancyEffectStyle: .tertiaryLabel,
+            description: "hig.materials.ios.vibrancy.tertiaryLabel.description"
+        ),
+        LabelVibrancy(
+            id: UUID(),
+            vibrancyEffectStyle: .quaternaryLabel,
+            description: "hig.materials.ios.vibrancy.quaternaryLabel.description"
+        ),
+    ]
+
+    var body: some View {
+        VStack {
+            Text("hig.materials.ios.vibrancy.title")
+                .font(.title)
+
+            ZStack {
+                Image("watercolor")
+                    .resizable()
+
+                VStack {
+                    VStack {
+                        Text("hig.materials.ios.vibrancy.label.description")
+                            .font(.body)
+                        ForEach(labelVibrancies) { labelVibrancy in
+                            HStack {
+                                SampleImage(
+                                    blurEffectStyle: .systemMaterial,
+                                    vibrancyEffectStyle: labelVibrancy.vibrancyEffectStyle
+                                )
+                                    .frame(width: 50, height: 50)
+                                Text(labelVibrancy.description)
+                                    .frame(maxWidth: .infinity, alignment: .leading)
+                            }
+                            .padding()
+                            .background(.regularMaterial)
+                        }
+                    }.padding()
+
+                    VStack {
+                        Text("hig.materials.ios.vibrancy.separator.description")
+                            .font(.body)
+                        SampleDivider(blurEffectStyle: .systemMaterial)
+                            .frame(height: 5)
+                    }
+                    .padding()
+                }
+            }
+            .padding()
+        }
+    }
+}
+
+// MARK: - LabelVibrancy
+
+private struct LabelVibrancy: Identifiable {
+    var id: UUID
+    var vibrancyEffectStyle: UIVibrancyEffectStyle
+    var description: LocalizedStringKey
+}
+
+// MARK: - Sample views
+
+private struct SampleImage: UIViewRepresentable {
+    private var blurEffectStyle: UIBlurEffect.Style
+    private var vibrancyEffectStyle: UIVibrancyEffectStyle
+
+    init(
+        blurEffectStyle: UIBlurEffect.Style,
+        vibrancyEffectStyle: UIVibrancyEffectStyle
+    ) {
+        self.blurEffectStyle = blurEffectStyle
+        self.vibrancyEffectStyle = vibrancyEffectStyle
+    }
+
+    func makeUIView(context: Context) -> UIView {
+        let imageView = UIImageView(image: UIImage(systemName: "square.and.arrow.up"))
+        imageView.contentMode = .scaleAspectFit
+        let visualEffectView = UIVisualEffectView(
+            effect: UIVibrancyEffect(
+                blurEffect: UIBlurEffect(style: blurEffectStyle),
+                style: vibrancyEffectStyle
+            )
+        )
+        visualEffectView.contentView.addSubview(imageView)
+        imageView.translatesAutoresizingMaskIntoConstraints = false
+        NSLayoutConstraint.activate([
+            imageView.widthAnchor.constraint(equalTo: visualEffectView.contentView.widthAnchor),
+            imageView.heightAnchor.constraint(equalTo: visualEffectView.contentView.heightAnchor),
+            imageView.centerXAnchor.constraint(equalTo: visualEffectView.contentView.centerXAnchor),
+            imageView.centerYAnchor.constraint(equalTo: visualEffectView.contentView.centerYAnchor),
+        ])
+
+        return visualEffectView
+    }
+
+    func updateUIView(_ uiView: UIView, context: Context) {
+    }
+}
+
+private struct SampleDivider: UIViewRepresentable {
+    private var blurEffectStyle: UIBlurEffect.Style
+
+    init(
+        blurEffectStyle: UIBlurEffect.Style
+    ) {
+        self.blurEffectStyle = blurEffectStyle
+    }
+
+    func makeUIView(context: Context) -> UIView {
+        let separatorView = UIView()
+        separatorView.backgroundColor = .separator
+        let visualEffectView = UIVisualEffectView(
+            effect: UIVibrancyEffect(
+                blurEffect: UIBlurEffect(style: blurEffectStyle),
+                style: .separator
+            )
+        )
+        visualEffectView.contentView.addSubview(separatorView)
+        separatorView.translatesAutoresizingMaskIntoConstraints = false
+        NSLayoutConstraint.activate([
+            separatorView.widthAnchor.constraint(equalTo: visualEffectView.contentView.widthAnchor),
+            separatorView.heightAnchor.constraint(equalToConstant: 5),
+            separatorView.centerXAnchor.constraint(equalTo: visualEffectView.contentView.centerXAnchor),
+            separatorView.centerYAnchor.constraint(equalTo: visualEffectView.contentView.centerYAnchor),
+        ])
+
+        return visualEffectView
+    }
+
+    func updateUIView(_ uiView: UIView, context: Context) {
+    }
+}
+
+// MARK: - Xcode Preview
+
+#Preview("VibrancyView(locale=enUS,colorScheme=light)") {
+    VibrancyView()
+        .environment(\.locale, .enUS)
+        .environment(\.colorScheme, .light)
+}
+
+#Preview("VibrancyView(locale=enUS,colorScheme=dark)") {
+    VibrancyView()
+        .environment(\.colorScheme, .dark)
+}
+
+#Preview("VibrancyView(locale=jaJP,colorScheme=light)") {
+    VibrancyView()
+        .environment(\.locale, .jaJP)
+        .environment(\.colorScheme, .light)
+}
+
+#Preview("SampleImage") {
+    SampleImage(
+        blurEffectStyle: .regular,
+        vibrancyEffectStyle: .label
+    )
+}


### PR DESCRIPTION
Closes #50 

# Changes

- SampleViewer/Localizable.xcstrings
    - Add description of sample
- SampleViewer/View/VibrancyView.swift
    - Add sample view

# Screenshots

||enUS|jaJP|
|---|---|---|
|light||<img src=https://github.com/user-attachments/assets/36d6bb06-3a5a-4441-ab13-c65e81c0130a width=200>|
|dark|<img src=https://github.com/user-attachments/assets/daef273c-6d6f-40cd-a783-c079d1020e24 width=200>|<img src=https://github.com/user-attachments/assets/7920a20b-a117-4b1a-906c-1dc8db32ca25 width=200>|