### PR TITLE
Add a sample view for number systems

### DIFF
--- a/SampleViewer/Localizable.xcstrings
+++ b/SampleViewer/Localizable.xcstrings
@@ -562,6 +562,91 @@
         }
       }
     },
+    "hig.right-to-left.number-system.ar_AE.title" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Arabic, United Arab Emirates"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "アラビア語、アラブ首長国連邦"
+          }
+        }
+      }
+    },
+    "hig.right-to-left.number-system.ar_SA.title" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Arabic, Saudi Arabia"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "アラビア語、サウジアラビア"
+          }
+        }
+      }
+    },
+    "hig.right-to-left.number-system.description" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "The use of Western and Eastern Arabic numerals varies among countries and regions and even among areas within the same country or region."
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "西アラビア数字とインド数字のどちらが使用されるかは、国や地域によって、さらには同じ国や地域内の場所によって異なります。"
+          }
+        }
+      }
+    },
+    "hig.right-to-left.number-system.en_US.title" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "English, U.S.A."
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "英語、米国"
+          }
+        }
+      }
+    },
+    "hig.right-to-left.number-system.title" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Number System"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "記数法"
+          }
+        }
+      }
+    },
     "sample.description" : {
       "extractionState" : "manual",
       "localizations" : {

--- a/SampleViewer/View/NumberSystemView.swift
+++ b/SampleViewer/View/NumberSystemView.swift
@@ -1,0 +1,65 @@
+import SwiftUI
+
+struct NumberSystemView: View {
+    private var localeConfigurations = [
+        LocaleConfiguration(
+            id: UUID(),
+            locale: "en_US",
+            description: "hig.right-to-left.number-system.en_US.title"
+        ),
+        LocaleConfiguration(
+            id: UUID(),
+            locale: "ar_SA",
+            description: "hig.right-to-left.number-system.ar_SA.title"
+        ),
+        LocaleConfiguration(
+            id: UUID(),
+            locale: "ar_AE",
+            description: "hig.right-to-left.number-system.ar_AE.title"
+        ),
+    ]
+
+    private var date: Date
+
+    init(date: Date) {
+        self.date = date
+    }
+
+    var body: some View {
+        VStack {
+            Text("hig.right-to-left.number-system.title")
+                .font(.title)
+            Text("hig.right-to-left.number-system.description")
+                .font(.body)
+
+            ForEach(localeConfigurations) { localeConfiguration in
+                GroupBox(localeConfiguration.description) {
+                    Text(date, format: Date.FormatStyle(date: .numeric, time: .omitted))
+                        .padding()
+                }
+                .environment(\.locale, .init(identifier: localeConfiguration.locale))
+            }
+        }
+        .padding()
+    }
+}
+
+// MARK: - LocaleConfiguration
+
+private struct LocaleConfiguration: Identifiable {
+    var id: UUID
+    var locale: String
+    var description: LocalizedStringKey
+}
+
+// MARK: - Xcode Preview
+
+#Preview("NumberSystemView(locale=enUS)") {
+    NumberSystemView(date: .now)
+        .environment(\.locale, .enUS)
+}
+
+#Preview("NumberSystemView(locale=jaJP)") {
+    NumberSystemView(date: .now)
+        .environment(\.locale, .jaJP)
+}


### PR DESCRIPTION
Closes #22

# Changes

- SampleViewer/Localizable.xcstrings
    - Add description texts on the sample
- SampleViewer/View/NumberSystemView.swift
    - Add the sample view

# Screenshots

|enUS|jaJP|
|---|---|
|<img src=https://github.com/user-attachments/assets/edf0bca3-c5cb-4a41-ad85-2f6e6a57f6b6 width=200>|<img src=https://github.com/user-attachments/assets/0b3cdead-40c0-42a1-9666-d85742259813 width=200>|