### PR TITLE
Update NumberSystemView logic and Localizable.xcstrings related to RTL locales

### DIFF
--- a/Package/Sources/Localization/Locale.swift
+++ b/Package/Sources/Localization/Locale.swift
@@ -3,4 +3,7 @@ import Foundation
 extension Locale {
     public static let jaJP = Locale(identifier: "ja_JP")
     public static let enUS = Locale(identifier: "en_US")
+    public static let arAE = Locale(identifier: "ar_AE")
+    public static let arSA = Locale(identifier: "ar_SA")
+    public static let heIL = Locale(identifier: "he_IL")
 }

--- a/Package/Tests/LocalizationTests/LocaleTest.swift
+++ b/Package/Tests/LocalizationTests/LocaleTest.swift
@@ -8,6 +8,9 @@ struct LocaleTest {
         let locales: [Locale] = [
             .jaJP,
             .enUS,
+            .arAE,
+            .arSA,
+            .heIL,
         ]
         #expect(locales.allSatisfy { Locale.availableIdentifiers.contains($0.identifier) })
     }

--- a/SampleViewer/Localizable.xcstrings
+++ b/SampleViewer/Localizable.xcstrings
@@ -562,40 +562,6 @@
         }
       }
     },
-    "hig.right-to-left.number-system.ar_AE.title" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Arabic, United Arab Emirates"
-          }
-        },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "アラビア語、アラブ首長国連邦"
-          }
-        }
-      }
-    },
-    "hig.right-to-left.number-system.ar_SA.title" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Arabic, Saudi Arabia"
-          }
-        },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "アラビア語、サウジアラビア"
-          }
-        }
-      }
-    },
     "hig.right-to-left.number-system.description" : {
       "extractionState" : "manual",
       "localizations" : {
@@ -613,23 +579,6 @@
         }
       }
     },
-    "hig.right-to-left.number-system.en_US.title" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "English, U.S.A."
-          }
-        },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "英語、米国"
-          }
-        }
-      }
-    },
     "hig.right-to-left.number-system.title" : {
       "extractionState" : "manual",
       "localizations" : {
@@ -643,6 +592,57 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "記数法"
+          }
+        }
+      }
+    },
+    "locale.ar_AE" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Arabic, United Arab Emirates"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "アラビア語、アラブ首長国連邦"
+          }
+        }
+      }
+    },
+    "locale.ar_SA" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Arabic, Saudi Arabia"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "アラビア語、サウジアラビア"
+          }
+        }
+      }
+    },
+    "locale.en_US" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "English, U.S.A."
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "英語、米国"
           }
         }
       }

--- a/SampleViewer/View/NumberSystemView.swift
+++ b/SampleViewer/View/NumberSystemView.swift
@@ -4,17 +4,17 @@ struct NumberSystemView: View {
     private var localeConfigurations = [
         LocaleConfiguration(
             id: UUID(),
-            locale: "en_US",
+            locale: .enUS,
             description: "hig.right-to-left.number-system.en_US.title"
         ),
         LocaleConfiguration(
             id: UUID(),
-            locale: "ar_SA",
+            locale: .arSA,
             description: "hig.right-to-left.number-system.ar_SA.title"
         ),
         LocaleConfiguration(
             id: UUID(),
-            locale: "ar_AE",
+            locale: .arAE,
             description: "hig.right-to-left.number-system.ar_AE.title"
         ),
     ]
@@ -37,7 +37,7 @@ struct NumberSystemView: View {
                     Text(date, format: Date.FormatStyle(date: .numeric, time: .omitted))
                         .padding()
                 }
-                .environment(\.locale, .init(identifier: localeConfiguration.locale))
+                .environment(\.locale, localeConfiguration.locale)
             }
         }
         .padding()
@@ -48,7 +48,7 @@ struct NumberSystemView: View {
 
 private struct LocaleConfiguration: Identifiable {
     var id: UUID
-    var locale: String
+    var locale: Locale
     var description: LocalizedStringKey
 }
 

--- a/SampleViewer/View/NumberSystemView.swift
+++ b/SampleViewer/View/NumberSystemView.swift
@@ -5,17 +5,17 @@ struct NumberSystemView: View {
         LocaleConfiguration(
             id: UUID(),
             locale: .enUS,
-            description: "hig.right-to-left.number-system.en_US.title"
+            description: "locale.en_US"
         ),
         LocaleConfiguration(
             id: UUID(),
             locale: .arSA,
-            description: "hig.right-to-left.number-system.ar_SA.title"
+            description: "locale.ar_SA"
         ),
         LocaleConfiguration(
             id: UUID(),
             locale: .arAE,
-            description: "hig.right-to-left.number-system.ar_AE.title"
+            description: "locale.ar_AE"
         ),
     ]
 


### PR DESCRIPTION
Closes #54

# Changes

- d0d79ef3c6b71e7b49b853dcab7007c466bbe458
    - Replace raw string with `Locale.xx_XX`
- 8dfbe33c7e9f16e775b273256516c3f568316cb5
    - Change key name to use the keys on other views

# Screenshots

<img src=https://github.com/user-attachments/assets/f36b18b9-d967-47c1-9765-87614167ea4a width=200>
