### PR TITLE
Add a sample view for font size of RTL scripts

### DIFF
--- a/SampleViewer/Localizable.xcstrings
+++ b/SampleViewer/Localizable.xcstrings
@@ -562,6 +562,40 @@
         }
       }
     },
+    "hig.right-to-left.font-size.description" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "In buttons, labels, and titles, Arabic or Hebrew text can appear too small when next to uppercased Latin text, because Arabic and Hebrew don’t include uppercase letters. To visually balance Arabic or Hebrew text with Latin text that uses all capitals, it often works well to increase the RTL font size by about 2 points."
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "ボタン、ラベル、タイトルでは、アラビア文字またはヘブライ文字のテキストを大文字ラテン文字の横に配置すると、小さすぎるように見えることがあります。アラビア文字とヘブライ文字には大文字が含まれないからです。アラビア文字またはヘブライ文字のテキストとすべて大文字のラテン文字のテキストとの視覚的なバランスを取るには、多くの場合RTLのフォントサイズを2ポイントほど大きくするとうまくいきます。"
+          }
+        }
+      }
+    },
+    "hig.right-to-left.font-size.title" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "RTL font size"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "RTLのフォントサイズ"
+          }
+        }
+      }
+    },
     "hig.right-to-left.number-system.description" : {
       "extractionState" : "manual",
       "localizations" : {

--- a/SampleViewer/View/RTLVisuallyBalanceView.swift
+++ b/SampleViewer/View/RTLVisuallyBalanceView.swift
@@ -1,0 +1,77 @@
+import SwiftUI
+
+struct RTLVisuallyBalanceView: View {
+    var body: some View {
+        VStack {
+            Text("hig.right-to-left.font-size.title")
+                .font(.title)
+            Text("hig.right-to-left.font-size.description")
+                .font(.body)
+        }
+        .padding()
+
+        GroupBox {
+            HStack {
+                Button {
+                } label: {
+                    Text(verbatim: "Download")
+                        .font(.system(size: 20))
+                }
+                .buttonStyle(.borderedProminent)
+                Button {
+                } label: {
+                    Text(verbatim: "تنزيل")
+                        .font(.system(size: 20))
+                }
+                .buttonStyle(.borderedProminent)
+                Button {
+                } label: {
+                    Text(verbatim: "הורד")
+                        .font(.system(size: 20))
+                }
+                .buttonStyle(.borderedProminent)
+            }
+        } label: {
+            Text(verbatim: "(20pt, 20pt, 20pt)")
+        }
+        .padding()
+
+        GroupBox {
+            HStack {
+                Button {
+                } label: {
+                    Text(verbatim: "Download")
+                        .font(.system(size: 20))
+                }
+                .buttonStyle(.borderedProminent)
+                Button {
+                } label: {
+                    Text(verbatim: "تنزيل")
+                        .font(.system(size: 22))
+                }
+                .buttonStyle(.borderedProminent)
+                Button {
+                } label: {
+                    Text(verbatim: "הורד")
+                        .font(.system(size: 22))
+                }
+                .buttonStyle(.borderedProminent)
+            }
+        } label: {
+            Text(verbatim: "(20pt, 22pt, 22pt)")
+        }
+        .padding()
+    }
+}
+
+// MARK: - Xcode Preview
+
+#Preview("RTLVisuallyBalanceView(locale=enUS)") {
+    RTLVisuallyBalanceView()
+        .environment(\.locale, .enUS)
+}
+
+#Preview("RTLVisuallyBalanceView(locale=jaJP)") {
+    RTLVisuallyBalanceView()
+        .environment(\.locale, .jaJP)
+}


### PR DESCRIPTION
Closes #25

# Changes

- SampleViewer/Localizable.xcstrings
    - Add description texts
- SampleViewer/View/RTLVisuallyBalanceView.swift
    - Add the sample view 

# Screenshots

|enUS|jaJP|
|---|---|
|<img src=https://github.com/user-attachments/assets/1347e8a8-0517-4efb-b956-45e1dbea0208 width=200>|<img src=https://github.com/user-attachments/assets/1a89d2f0-8f1b-44ae-a20d-5e1844c087f3 width=200>|