### PR TITLE
Add a sample view for interface icon in RTL

### DIFF
--- a/SampleViewer/Localizable.xcstrings
+++ b/SampleViewer/Localizable.xcstrings
@@ -596,6 +596,193 @@
         }
       }
     },
+    "hig.right-to-left.interface.backslash.title" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Interface icons that include a backslash"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "バックスラッシュを含むシンボル"
+          }
+        }
+      }
+    },
+    "hig.right-to-left.interface.component.title" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Flip a component (or its position)"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "コンポーネント（またはその位置）を反転"
+          }
+        }
+      }
+    },
+    "hig.right-to-left.interface.description" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "When you use SF Symbols to supply interface icons for your app, you get variants for the RTL context and localized symbols for Arabic and Hebrew, among other languages."
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "SF Symbolsを使ってアプリのインターフェイスアイコンを利用する場合は、RTLコンテキスト用のバリエーションとアラビア語やヘブライ語などの言語用にローカライズされたシンボルを利用できます。"
+          }
+        }
+      }
+    },
+    "hig.right-to-left.interface.directional.title" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Directional interface icons"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "方向のあるシンボル"
+          }
+        }
+      }
+    },
+    "hig.right-to-left.interface.localized.title" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Interface icons that display text"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "テキストを含むインターフェイスアイコン"
+          }
+        }
+      }
+    },
+    "hig.right-to-left.interface.motion.title" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Interface icons that show forward or backward motion"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "前方または後方への動きを示すインターフェイスアイコン"
+          }
+        }
+      }
+    },
+    "hig.right-to-left.interface.text.title" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Interface icons that represent text or reading direction"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "テキストまたは読む方向を表すインターフェイスアイコン"
+          }
+        }
+      }
+    },
+    "hig.right-to-left.interface.title" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Interface icons"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "インターフェイスアイコン"
+          }
+        }
+      }
+    },
+    "hig.right-to-left.interface.tool.title" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Interface icons that depict a tool"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "道具を表すシンボル"
+          }
+        }
+      }
+    },
+    "hig.right-to-left.interface.variant.ltr.description" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "LTR variant(s)"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "LTRバリエーション"
+          }
+        }
+      }
+    },
+    "hig.right-to-left.interface.variant.rtl.description" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "RTL variant(s)"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "RTLバリエーション"
+          }
+        }
+      }
+    },
     "hig.right-to-left.number-system.description" : {
       "extractionState" : "manual",
       "localizations" : {
@@ -626,6 +813,40 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "記数法"
+          }
+        }
+      }
+    },
+    "hig.right-to-left.rating.description" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Controls like progress bars, sliders, and rating controls often include numerals to clarify their meaning. If you use numerals in this way, be sure to reverse the order of the numerals to match the direction of the flipped control. Also reverse a sequence of numerals if you use the sequence to communicate a specific order."
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "進行状況バー、スライダ、評価コントロールなどのコントロールには、意味を明瞭にするために数字が含まれることがよくあります。数字をこのように使用する場合は、反転したコントロールの向きに合わせて必ず数字を逆順にしてください。また、数字のシーケンスを使って特定の順序を伝える場合は、シーケンスを逆順にします。"
+          }
+        }
+      }
+    },
+    "hig.right-to-left.rating.title" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Numerals that show progress or a counting direction"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "進行状況またはカウントの方向を示す数字"
           }
         }
       }
@@ -677,40 +898,6 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "英語、米国"
-          }
-        }
-      }
-    },
-    "hig.right-to-left.rating.description" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Controls like progress bars, sliders, and rating controls often include numerals to clarify their meaning. If you use numerals in this way, be sure to reverse the order of the numerals to match the direction of the flipped control. Also reverse a sequence of numerals if you use the sequence to communicate a specific order."
-          }
-        },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "進行状況バー、スライダ、評価コントロールなどのコントロールには、意味を明瞭にするために数字が含まれることがよくあります。数字をこのように使用する場合は、反転したコントロールの向きに合わせて必ず数字を逆順にしてください。また、数字のシーケンスを使って特定の順序を伝える場合は、シーケンスを逆順にします。"
-          }
-        }
-      }
-    },
-    "hig.right-to-left.rating.title" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Numerals that show progress or a counting direction"
-          }
-        },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "進行状況またはカウントの方向を示す数字"
           }
         }
       }

--- a/SampleViewer/View/InterfaceIconView.swift
+++ b/SampleViewer/View/InterfaceIconView.swift
@@ -1,0 +1,172 @@
+import SwiftUI
+
+struct InterfaceIconView: View {
+    private var layoutDirectionContexts = [
+        LayoutDirectionContext(
+            id: UUID(),
+            layoutDirection: .leftToRight,
+            description: "hig.right-to-left.interface.variant.ltr.description"
+        ),
+        LayoutDirectionContext(
+            id: UUID(),
+            layoutDirection: .rightToLeft,
+            description: "hig.right-to-left.interface.variant.rtl.description"
+        ),
+    ]
+
+    private var localeContexts = [
+        LocaleContext(
+            id: UUID(),
+            locale: .enUS,
+            description: "locale.en_US"
+        ),
+        LocaleContext(
+            id: UUID(),
+            locale: .heIL,
+            description: "locale.he_IL"
+        ),
+        LocaleContext(
+            id: UUID(),
+            locale: .arAE,
+            description: "locale.ar_AE"
+        ),
+    ]
+
+    var body: some View {
+        VStack {
+            Text("hig.right-to-left.interface.title")
+                .font(.title)
+            Text("hig.right-to-left.interface.description")
+                .font(.body)
+        }
+        .padding()
+        ScrollView {
+            Section("hig.right-to-left.interface.directional.title") {
+                ForEach(layoutDirectionContexts) { layoutDirectionContexts in
+                    GroupBox {
+                        HStack {
+                            Image(systemName: "list.bullet")
+                                .environment(\.layoutDirection, layoutDirectionContexts.layoutDirection)
+                            Image(systemName: "book.closed")
+                                .environment(\.layoutDirection, layoutDirectionContexts.layoutDirection)
+                            Image(systemName: "rectangle.and.pencil.and.ellipsis")
+                                .environment(\.layoutDirection, layoutDirectionContexts.layoutDirection)
+                            Image(systemName: "macwindow")
+                                .environment(\.layoutDirection, layoutDirectionContexts.layoutDirection)
+                            Image(systemName: "battery.25percent")
+                                .environment(\.layoutDirection, layoutDirectionContexts.layoutDirection)
+                        }
+                    } label: {
+                        Text(layoutDirectionContexts.description)
+                    }
+                }
+            }
+
+            Section("hig.right-to-left.interface.text.title") {
+                ForEach(layoutDirectionContexts) { layoutDirectionContexts in
+                    GroupBox {
+                        HStack {
+                            Image(systemName: "text.page")
+                                .environment(\.layoutDirection, layoutDirectionContexts.layoutDirection)
+                        }
+                    } label: {
+                        Text(layoutDirectionContexts.description)
+                    }
+                }
+            }
+
+            Section("hig.right-to-left.interface.localized.title") {
+                ForEach(localeContexts) { localeContext in
+                    GroupBox {
+                        HStack {
+                            Image(systemName: "signature")
+                            Image(systemName: "richtext.page")
+                            Image(systemName: "character.cursor.ibeam")
+                        }
+                        .environment(\.locale, localeContext.locale)
+                    } label: {
+                        Text(localeContext.description)
+                    }
+                }
+            }
+
+            Section("hig.right-to-left.interface.motion.title") {
+                ForEach(layoutDirectionContexts) { layoutDirectionContexts in
+                    GroupBox {
+                        HStack {
+                            Image(systemName: "speaker.wave.3.fill")
+                                .environment(\.layoutDirection, layoutDirectionContexts.layoutDirection)
+                        }
+                    } label: {
+                        Text(layoutDirectionContexts.description)
+                    }
+                }
+            }
+
+            Section("hig.right-to-left.interface.backslash.title") {
+                ForEach(layoutDirectionContexts) { layoutDirectionContexts in
+                    GroupBox {
+                        HStack {
+                            Image(systemName: "speaker.slash.fill")
+                                .environment(\.layoutDirection, layoutDirectionContexts.layoutDirection)
+                        }
+                    } label: {
+                        Text(layoutDirectionContexts.description)
+                    }
+                }
+            }
+
+            Section("hig.right-to-left.interface.component.title") {
+                ForEach(layoutDirectionContexts) { layoutDirectionContexts in
+                    GroupBox {
+                        HStack {
+                            Image(systemName: "cart.fill.badge.plus")
+                                .environment(\.layoutDirection, layoutDirectionContexts.layoutDirection)
+                        }
+                    } label: {
+                        Text(layoutDirectionContexts.description)
+                    }
+                }
+            }
+
+            Section("hig.right-to-left.interface.tool.title") {
+                ForEach(layoutDirectionContexts) { layoutDirectionContexts in
+                    GroupBox {
+                        HStack {
+                            Image(systemName: "mail.and.text.magnifyingglass")
+                                .environment(\.layoutDirection, layoutDirectionContexts.layoutDirection)
+                        }
+                    } label: {
+                        Text(layoutDirectionContexts.description)
+                    }
+                }
+            }
+        }.padding()
+    }
+}
+
+// MARK: - Context
+
+private struct LayoutDirectionContext: Identifiable {
+    var id: UUID
+    var layoutDirection: LayoutDirection
+    var description: LocalizedStringKey
+}
+
+private struct LocaleContext: Identifiable {
+    var id: UUID
+    var locale: Locale
+    var description: LocalizedStringKey
+}
+
+// MARK: - Xcode Preview
+
+#Preview("InterfaceIconView(locale=enUS)") {
+    InterfaceIconView()
+        .environment(\.locale, .enUS)
+}
+
+#Preview("InterfaceIconView(locale=jaJP)") {
+    InterfaceIconView()
+        .environment(\.locale, .jaJP)
+}


### PR DESCRIPTION
Closes #26

# Changes

- SampleViewer/Localizable.xcstrings
    - Add description texts on the sample
- SampleViewer/View/InterfaceIconView.swift
    - Add a sample view

# Screenshots

|enUS|jaJP|
|---|---|
|<img src=https://github.com/user-attachments/assets/aaede5d6-5642-4680-ab68-948214054c9e width=200>|<img src=https://github.com/user-attachments/assets/8d071273-d2f7-4fb9-bfd8-bf950dcea92e width=200>|
|<img src=https://github.com/user-attachments/assets/6b0c1f43-f555-4921-84bf-774669a03a4e width=200>|<img src=https://github.com/user-attachments/assets/0014c662-2f96-4639-ba68-5714c6d81bf9 width=200>|
|<img src=https://github.com/user-attachments/assets/b576e509-61de-4537-ac60-885b5f7cae42 width=200>|<img src=https://github.com/user-attachments/assets/4a79d7b5-1907-421f-8cbc-1e09a4e0fde7 width=200>|