### PR TITLE
Add a sample view for SF Symbols rendering modes

### DIFF
--- a/SampleViewer/Localizable.xcstrings
+++ b/SampleViewer/Localizable.xcstrings
@@ -664,6 +664,108 @@
         }
       }
     },
+    "hig.sf-symbols.rendering.description" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "SF Symbols provides four rendering modes — monochrome, hierarchical, palette, and multicolor — that give you multiple options when applying color to symbols."
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "SF Symbolsには、モノクロ、階層、パレット、マルチカラーの4つのレンダリングモードがあります。"
+          }
+        }
+      }
+    },
+    "hig.sf-symbols.rendering.hierarchical.description" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Hierarchical"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "階層"
+          }
+        }
+      }
+    },
+    "hig.sf-symbols.rendering.monochrome.description" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Monochrome"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "モノクロ"
+          }
+        }
+      }
+    },
+    "hig.sf-symbols.rendering.multicolor.description" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Multicolor"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "マルチカラー"
+          }
+        }
+      }
+    },
+    "hig.sf-symbols.rendering.palette.description" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Palette"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "パレット"
+          }
+        }
+      }
+    },
+    "hig.sf-symbols.rendering.title" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Rendering modes"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "レンダリングモード"
+          }
+        }
+      }
+    },
     "hig.right-to-left.interface.localized.title" : {
       "extractionState" : "manual",
       "localizations" : {

--- a/SampleViewer/View/SFSymbolRenderingView.swift
+++ b/SampleViewer/View/SFSymbolRenderingView.swift
@@ -1,0 +1,134 @@
+import SwiftUI
+
+/// - NOTE: `textformat.characters.dottedunderline` in Japanese language is rendered incorrectly.
+struct SFSymbolRenderingView: View {
+    private var symbolRenderingModeContexts = [
+        SymbolRenderingModeContext(
+            id: UUID(),
+            symbolRenderingMode: .monochrome,
+            description: "hig.sf-symbols.rendering.monochrome.description"
+        ),
+        SymbolRenderingModeContext(
+            id: UUID(),
+            symbolRenderingMode: .hierarchical,
+            description: "hig.sf-symbols.rendering.hierarchical.description"
+        ),
+        SymbolRenderingModeContext(
+            id: UUID(),
+            symbolRenderingMode: .palette,
+            description: "hig.sf-symbols.rendering.palette.description"
+        ),
+        SymbolRenderingModeContext(
+            id: UUID(),
+            symbolRenderingMode: .multicolor,
+            description: "hig.sf-symbols.rendering.multicolor.description"
+        ),
+    ]
+
+    private var sampleSFSymbols = [
+        "square.and.arrow.up",
+        "folder.badge.plus",
+        "trash.slash",
+        "calendar.day.timeline.trailing",
+        "list.number",
+        "textformat.characters.dottedunderline",
+        "iphone.gen3.radiowaves.left.and.right",
+        "pc"
+    ].map {
+        SampleSFSymbol(id: UUID(), systemName: $0)
+    }
+
+    var body: some View {
+        VStack {
+            Text("hig.sf-symbols.rendering.title")
+                .font(.title)
+            Text("hig.sf-symbols.rendering.description")
+                .font(.body)
+
+            GroupBox {
+                HStack {
+                    Image(systemName: "cloud.sun.rain.fill")
+                        .symbolRenderingMode(.palette)
+                        .foregroundStyle(Color.white, Color.gray, Color.gray)
+                    Image(systemName: "cloud.sun.rain.fill")
+                        .symbolRenderingMode(.palette)
+                        .foregroundStyle(Color.gray, Color.white, Color.gray)
+                    Image(systemName: "cloud.sun.rain.fill")
+                        .symbolRenderingMode(.palette)
+                        .foregroundStyle(Color.gray, Color.gray, Color.white)
+                    Image(systemName: "cloud.sun.rain.fill")
+                        .symbolRenderingMode(.hierarchical)
+                        .foregroundStyle(Color.accentColor)
+                }
+            } label: {
+                Text(verbatim: "cloud.sun.rain.fill")
+            }
+
+            GroupBox {
+                HStack {
+                    Image(systemName: "speaker.wave.3", variableValue: 0)
+                        .foregroundStyle(Color.accentColor)
+                    Image(systemName: "speaker.wave.3", variableValue: 0.3)
+                        .foregroundStyle(Color.accentColor)
+                    Image(systemName: "speaker.wave.3", variableValue: 0.6)
+                        .foregroundStyle(Color.accentColor)
+                    Image(systemName: "speaker.wave.3", variableValue: 1)
+                        .foregroundStyle(Color.accentColor)
+                }
+            } label: {
+                Text(verbatim: "speaker.wave.3")
+            }
+
+            ForEach(symbolRenderingModeContexts) { symbolRenderingModeContext in
+                GroupBox {
+                    HStack {
+                        ForEach(sampleSFSymbols) { sampleSFSymbol in
+                            Image(systemName: sampleSFSymbol.systemName)
+                                .symbolRenderingMode(symbolRenderingModeContext.symbolRenderingMode)
+                                .foregroundStyle(Color.accentColor, Color.gray)
+                        }
+                    }
+                } label: {
+                    Text(symbolRenderingModeContext.description)
+                }
+            }
+        }.padding()
+    }
+}
+
+private struct SampleSFSymbol: Identifiable {
+    var id: UUID
+    var systemName: String
+}
+
+private struct SymbolRenderingModeContext: Identifiable {
+    var id: UUID
+    var symbolRenderingMode: SymbolRenderingMode
+    var description: LocalizedStringKey
+}
+
+// MARK: - Xcode Preview
+
+#Preview("SFSymbolRenderingView(locale=enUS,colorScheme=light)") {
+    SFSymbolRenderingView()
+        .environment(\.locale, .enUS)
+        .environment(\.colorScheme, .light)
+}
+
+#Preview("SFSymbolRenderingView(locale=enUS,colorScheme=dark)") {
+    SFSymbolRenderingView()
+        .environment(\.locale, .enUS)
+        .environment(\.colorScheme, .dark)
+}
+
+#Preview("SFSymbolRenderingView(locale=jaJP,colorScheme=light)") {
+    SFSymbolRenderingView()
+        .environment(\.locale, .jaJP)
+        .environment(\.colorScheme, .light)
+}
+
+#Preview("SFSymbolRenderingView(locale=jaJP,colorScheme=dark)") {
+    SFSymbolRenderingView()
+        .environment(\.locale, .jaJP)
+        .environment(\.colorScheme, .dark)
+}


### PR DESCRIPTION
Closes #27
Closes #28

# Changes

- SampleViewer/Localizable.xcstrings
    - Add description texts
- SampleViewer/View/SFSymbolRenderingView.swift
    - Add a sample view

# Notes

"textformat.characters.dottedunderline" symbol is rendered incorrectly in ja_JP environment.

||enUS|jaJP|
|---|---|---|
|light|![Simulator Screenshot - iPhone 16 Pro Max - 2024-12-18 at 11 12 19 copy](https://github.com/user-attachments/assets/529fbbf2-d1e7-463c-822f-23cfa735640e)|![Simulator Screenshot - iPhone 16 Pro Max - 2024-12-18 at 11 11 26 copy](https://github.com/user-attachments/assets/309da708-0cc5-45d8-a5e7-29a04c68223e)|
|dark|![Simulator Screenshot - iPhone 16 Pro Max - 2024-12-18 at 11 08 05 copy](https://github.com/user-attachments/assets/ab6bd6d4-f19c-49ea-aaaf-e914cd465743)|![Simulator Screenshot - iPhone 16 Pro Max - 2024-12-18 at 11 07 28 copy](https://github.com/user-attachments/assets/814ef859-5a98-42e0-992c-faf78537cf41)|

# Screenshots

||enUS|jaJP|
|---|---|---|
|light|<img src=https://github.com/user-attachments/assets/18f9c7dc-6ad3-40aa-8c8f-23f01d89a48f width=200>|<img src=https://github.com/user-attachments/assets/0add3c12-3674-464b-9f07-2c2c3e6011b3 width=200>|
|dark|<img src=https://github.com/user-attachments/assets/b89a1be1-c9f9-499d-b5b7-1717b5f1e5d0 width=200>|<img src=https://github.com/user-attachments/assets/9c2b959f-177b-4e94-8a4c-615f4a482d70 width=200>|