### PR TITLE
Add a sample view for SF Symbols weight and scale

### DIFF
--- a/SampleViewer/Localizable.xcstrings
+++ b/SampleViewer/Localizable.xcstrings
@@ -664,108 +664,6 @@
         }
       }
     },
-    "hig.sf-symbols.rendering.description" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "SF Symbols provides four rendering modes — monochrome, hierarchical, palette, and multicolor — that give you multiple options when applying color to symbols."
-          }
-        },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "SF Symbolsには、モノクロ、階層、パレット、マルチカラーの4つのレンダリングモードがあります。"
-          }
-        }
-      }
-    },
-    "hig.sf-symbols.rendering.hierarchical.description" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Hierarchical"
-          }
-        },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "階層"
-          }
-        }
-      }
-    },
-    "hig.sf-symbols.rendering.monochrome.description" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Monochrome"
-          }
-        },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "モノクロ"
-          }
-        }
-      }
-    },
-    "hig.sf-symbols.rendering.multicolor.description" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Multicolor"
-          }
-        },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "マルチカラー"
-          }
-        }
-      }
-    },
-    "hig.sf-symbols.rendering.palette.description" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Palette"
-          }
-        },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "パレット"
-          }
-        }
-      }
-    },
-    "hig.sf-symbols.rendering.title" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Rendering modes"
-          }
-        },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "レンダリングモード"
-          }
-        }
-      }
-    },
     "hig.right-to-left.interface.localized.title" : {
       "extractionState" : "manual",
       "localizations" : {
@@ -949,6 +847,176 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "進行状況またはカウントの方向を示す数字"
+          }
+        }
+      }
+    },
+    "hig.sf-symbols.rendering.description" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "SF Symbols provides four rendering modes — monochrome, hierarchical, palette, and multicolor — that give you multiple options when applying color to symbols."
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "SF Symbolsには、モノクロ、階層、パレット、マルチカラーの4つのレンダリングモードがあります。"
+          }
+        }
+      }
+    },
+    "hig.sf-symbols.rendering.hierarchical.description" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Hierarchical"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "階層"
+          }
+        }
+      }
+    },
+    "hig.sf-symbols.rendering.monochrome.description" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Monochrome"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "モノクロ"
+          }
+        }
+      }
+    },
+    "hig.sf-symbols.rendering.multicolor.description" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Multicolor"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "マルチカラー"
+          }
+        }
+      }
+    },
+    "hig.sf-symbols.rendering.palette.description" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Palette"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "パレット"
+          }
+        }
+      }
+    },
+    "hig.sf-symbols.rendering.title" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Rendering modes"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "レンダリングモード"
+          }
+        }
+      }
+    },
+    "hig.sf-symbols.weight-and-scale.description" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "SF Symbols provides symbols in a wide range of weights and scales to help you create adaptable designs."
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "SF Symbolsでは、適応性の高いデザインを作成できるように、さまざまなウェイトとスケールのシンボルが提供されます。"
+          }
+        }
+      }
+    },
+    "hig.sf-symbols.weight-and-scale.scale.title" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Scales"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "スケール"
+          }
+        }
+      }
+    },
+    "hig.sf-symbols.weight-and-scale.title" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Weights and scales"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "ウェイトとスケール"
+          }
+        }
+      }
+    },
+    "hig.sf-symbols.weight-and-scale.weight.title" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Weights"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "ウェイト"
           }
         }
       }

--- a/SampleViewer/View/SFSymbolWeightView.swift
+++ b/SampleViewer/View/SFSymbolWeightView.swift
@@ -1,0 +1,115 @@
+import SwiftUI
+
+struct SFSymbolWeightView: View {
+    private var imageScales = [
+        ImageScale(id: UUID(), scale: .small),
+        ImageScale(id: UUID(), scale: .medium),
+        ImageScale(id: UUID(), scale: .large),
+    ]
+
+    private var fontWeights = [
+        FontWeight(
+            id: UUID(),
+            weight: .ultraLight,
+            description: "ultraLight"
+        ),
+        FontWeight(
+            id: UUID(),
+            weight: .thin,
+            description: "thin"
+        ),
+        FontWeight(
+            id: UUID(),
+            weight: .light,
+            description: "light"
+        ),
+        FontWeight(
+            id: UUID(),
+            weight: .regular,
+            description: "regular"
+        ),
+        FontWeight(
+            id: UUID(),
+            weight: .medium,
+            description: "medium"
+        ),
+        FontWeight(
+            id: UUID(),
+            weight: .semibold,
+            description: "semibold"
+        ),
+        FontWeight(
+            id: UUID(),
+            weight: .bold,
+            description: "bold"
+        ),
+        FontWeight(
+            id: UUID(),
+            weight: .heavy,
+            description: "heavy"
+        ),
+        FontWeight(
+            id: UUID(),
+            weight: .black,
+            description: "black"
+        ),
+    ]
+
+    var body: some View {
+        VStack {
+            Text("hig.sf-symbols.weight-and-scale.title")
+                .font(.title)
+            Text("hig.sf-symbols.weight-and-scale.description")
+                .font(.body)
+
+            GroupBox("hig.sf-symbols.weight-and-scale.weight.title") {
+                HStack {
+                    Label("Add", systemImage: "plus.circle")
+                        .imageScale(.small)
+                    Label("Add", systemImage: "plus.circle")
+                        .imageScale(.medium)
+                    Label("Add", systemImage: "plus.circle")
+                        .imageScale(.large)
+                }
+                .frame(maxWidth: .infinity)
+            }
+
+            GroupBox("hig.sf-symbols.weight-and-scale.scale.title") {
+                Grid {
+                    ForEach(fontWeights) { fontWeight in
+                        GridRow {
+                            ForEach(imageScales) { imageScale in
+                                Image(systemName: "folder.badge.plus")
+                                    .imageScale(imageScale.scale)
+                            }
+                        }
+                        .fontWeight(fontWeight.weight)
+                        .frame(maxWidth: .infinity)
+                    }
+                }
+            }
+        }
+        .padding()
+    }
+}
+
+private struct ImageScale: Identifiable {
+    var id: UUID
+    var scale: Image.Scale
+}
+
+private struct FontWeight: Identifiable {
+    var id: UUID
+    var weight: Font.Weight
+    var description: LocalizedStringKey
+}
+
+#Preview("SFSymbolWeightView(locale=enUS)") {
+    SFSymbolWeightView()
+        .environment(\.locale, .enUS)
+}
+
+#Preview("SFSymbolWeightView(locale=jaJP)") {
+    SFSymbolWeightView()
+        .environment(\.locale, .jaJP)
+}


### PR DESCRIPTION
Closes #29 

# Changes

- SampleViewer/Localizable.xcstrings
    - Add description texts on the sample view
- SampleViewer/View/SFSymbolWeightView.swift
    - Add the sample view

# Screenshots

|enUS|jaJP|
|---|---|
|<img src=https://github.com/user-attachments/assets/678523eb-efc4-42eb-9ac9-cc05b58fc816 width=200>|<img src=https://github.com/user-attachments/assets/3445e1b3-3372-4b1d-b69d-ad14cd1fc9b1 width=200>|