### PR TITLE
Add a sample view of `"heart"` symbol variants

### DIFF
--- a/SampleViewer/Localizable.xcstrings
+++ b/SampleViewer/Localizable.xcstrings
@@ -953,6 +953,40 @@
         }
       }
     },
+    "hig.sf-symbols.variant.description" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "SF Symbols defines several design variants — such as fill, slash, and enclosed — that can help you communicate precise states and actions while maintaining visual consistency and simplicity in your UI."
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "SF Symbolsでは、塗りつぶし、スラッシュ、囲みなどの複数のデザインバリアントが定義されています。これによって、UI内で視覚的な一貫性とシンプルさを保ちつつ、状態やアクションを正確に伝えることができます。"
+          }
+        }
+      }
+    },
+    "hig.sf-symbols.variant.title" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Design variants"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "デザインバリアント"
+          }
+        }
+      }
+    },
     "hig.sf-symbols.weight-and-scale.description" : {
       "extractionState" : "manual",
       "localizations" : {

--- a/SampleViewer/View/SFSymbolVariantView.swift
+++ b/SampleViewer/View/SFSymbolVariantView.swift
@@ -1,5 +1,6 @@
 import SwiftUI
 
+// TODO: Add icons to navigation bar and tab bar
 struct SFSymbolVariantView: View {
     var body: some View {
         VStack {

--- a/SampleViewer/View/SFSymbolVariantView.swift
+++ b/SampleViewer/View/SFSymbolVariantView.swift
@@ -1,0 +1,54 @@
+import SwiftUI
+
+struct SFSymbolVariantView: View {
+    var body: some View {
+        VStack {
+            Text("hig.sf-symbols.variant.title")
+                .font(.title)
+            Text("hig.sf-symbols.variant.description")
+                .font(.body)
+        }
+        .padding()
+
+        HStack {
+            Image(systemName: "heart")
+            Image(systemName: "heart")
+                .symbolVariant(.slash)
+            Image(systemName: "heart")
+                .symbolVariant(.circle)
+            Image(systemName: "heart")
+                .symbolVariant(.square)
+            Image(systemName: "heart")
+                .symbolVariant(.rectangle)
+        }
+
+        HStack {
+            Image(systemName: "heart")
+                .symbolVariant(.fill)
+            Image(systemName: "heart")
+                .symbolVariant(.fill)
+                .symbolVariant(.slash)
+            Image(systemName: "heart")
+                .symbolVariant(.fill)
+                .symbolVariant(.circle)
+            Image(systemName: "heart")
+                .symbolVariant(.fill)
+                .symbolVariant(.square)
+            Image(systemName: "heart")
+                .symbolVariant(.fill)
+                .symbolVariant(.rectangle)
+        }
+    }
+}
+
+// MARK: - Xcode Preview
+
+#Preview("SFSymbolVariantView(locale=enUS)") {
+    SFSymbolVariantView()
+        .environment(\.locale, .enUS)
+}
+
+#Preview("SFSymbolVariantView(locale=jaJP)") {
+    SFSymbolVariantView()
+        .environment(\.locale, .jaJP)
+}


### PR DESCRIPTION
Closes #61 

# Changes

- SampleViewer/Localizable.xcstrings
    - Add description texts on the sample view
- SampleViewer/View/SFSymbolVariantView.swift
    - Add the sample view

# Screenshots

|enUS|jaJP|
|---|---|
|<img src=https://github.com/user-attachments/assets/2c419033-1158-492d-9bd0-c2592de40eb7 width=200>|<img src=https://github.com/user-attachments/assets/131c3a71-1c67-4afd-ad71-3d4a82f1825e width=200>|