### PR TITLE
Add a sample view for language-specific SF Symbols variants

### DIFF
--- a/Package/Sources/Localization/Locale.swift
+++ b/Package/Sources/Localization/Locale.swift
@@ -6,4 +6,8 @@ extension Locale {
     public static let arAE = Locale(identifier: "ar_AE")
     public static let arSA = Locale(identifier: "ar_SA")
     public static let heIL = Locale(identifier: "he_IL")
+    public static let hiIN = Locale(identifier: "hi_IN")
+    public static let thTH = Locale(identifier: "th_TH")
+    public static let zhCN = Locale(identifier: "zh_CN")
+    public static let koKR = Locale(identifier: "ko_KR")
 }

--- a/Package/Tests/LocalizationTests/LocaleTest.swift
+++ b/Package/Tests/LocalizationTests/LocaleTest.swift
@@ -11,6 +11,10 @@ struct LocaleTest {
             .arAE,
             .arSA,
             .heIL,
+            .hiIN,
+            .thTH,
+            .zhCN,
+            .koKR,
         ]
         #expect(locales.allSatisfy { Locale.availableIdentifiers.contains($0.identifier) })
     }

--- a/SampleViewer/Localizable.xcstrings
+++ b/SampleViewer/Localizable.xcstrings
@@ -1,6 +1,23 @@
 {
   "sourceLanguage" : "en",
   "strings" : {
+    "button.seemore" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "See more"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "もっと見る"
+          }
+        }
+      }
+    },
     "hig.accessibility.controls.configuration.description" : {
       "extractionState" : "manual",
       "localizations" : {
@@ -970,6 +987,40 @@
         }
       }
     },
+    "hig.sf-symbols.variant.language-specific.description" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "SF Symbols provides many variants for specific languages and writing systems, including Latin, Arabic, Hebrew, Hindi, Thai, Chinese, Japanese, Korean, Cyrillic, Devanagari, and several Indic numeral systems."
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "SF Symbolsには、ラテン文字、アラビア語、ヘブライ語、ヒンディー語、タイ語、中国語、日本語、韓国語、キリル文字、デーバナーガリー数字や、複数のインド数字など、特定の言語や表記法向けのバリアントが多数用意されています。"
+          }
+        }
+      }
+    },
+    "hig.sf-symbols.variant.language-specific.title" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Language- and script-specific variants"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "言語および文字固有のバリアント"
+          }
+        }
+      }
+    },
     "hig.sf-symbols.variant.title" : {
       "extractionState" : "manual",
       "localizations" : {
@@ -1123,6 +1174,23 @@
         }
       }
     },
+    "locale.hi_IN" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Hindi, India"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "ヒンズー語、インド"
+          }
+        }
+      }
+    },
     "locale.ja_JP" : {
       "extractionState" : "manual",
       "localizations" : {
@@ -1136,6 +1204,57 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "日本語、日本"
+          }
+        }
+      }
+    },
+    "locale.ko_KR" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Korean, Korea"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "韓国語、韓国"
+          }
+        }
+      }
+    },
+    "locale.th_TH" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Thai, Thailand"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "タイ語、タイ"
+          }
+        }
+      }
+    },
+    "locale.zh_CN" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Simplified Chinese, China"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "簡体字中国語、中国"
           }
         }
       }

--- a/SampleViewer/View/InterfaceIconView.swift
+++ b/SampleViewer/View/InterfaceIconView.swift
@@ -33,115 +33,125 @@ struct InterfaceIconView: View {
     ]
 
     var body: some View {
-        VStack {
-            Text("hig.right-to-left.interface.title")
-                .font(.title)
+        NavigationStack {
             Text("hig.right-to-left.interface.description")
                 .font(.body)
+            .padding()
+            ScrollView {
+                Section("hig.right-to-left.interface.directional.title") {
+                    ForEach(layoutDirectionContexts) { layoutDirectionContexts in
+                        GroupBox {
+                            HStack {
+                                Image(systemName: "list.bullet")
+                                    .environment(\.layoutDirection, layoutDirectionContexts.layoutDirection)
+                                Image(systemName: "book.closed")
+                                    .environment(\.layoutDirection, layoutDirectionContexts.layoutDirection)
+                                Image(systemName: "rectangle.and.pencil.and.ellipsis")
+                                    .environment(\.layoutDirection, layoutDirectionContexts.layoutDirection)
+                                Image(systemName: "macwindow")
+                                    .environment(\.layoutDirection, layoutDirectionContexts.layoutDirection)
+                                Image(systemName: "battery.25percent")
+                                    .environment(\.layoutDirection, layoutDirectionContexts.layoutDirection)
+                            }
+                        } label: {
+                            Text(layoutDirectionContexts.description)
+                        }
+                    }
+                }
+
+                Section("hig.right-to-left.interface.text.title") {
+                    ForEach(layoutDirectionContexts) { layoutDirectionContexts in
+                        GroupBox {
+                            HStack {
+                                Image(systemName: "text.page")
+                                    .environment(\.layoutDirection, layoutDirectionContexts.layoutDirection)
+                            }
+                        } label: {
+                            Text(layoutDirectionContexts.description)
+                        }
+                    }
+                }
+
+                Section("hig.right-to-left.interface.localized.title") {
+                    ForEach(localeContexts) { localeContext in
+                        GroupBox {
+                            HStack {
+                                Image(systemName: "signature")
+                                Image(systemName: "richtext.page")
+                                Image(systemName: "character.cursor.ibeam")
+                            }
+                            .environment(\.locale, localeContext.locale)
+                        } label: {
+                            Text(localeContext.description)
+                        }
+                    }
+
+                    NavigationLink(
+                        destination: LanguageSpecificSFSymbolView()
+                    ) {
+                        Text("button.seemore")
+                            .frame(maxWidth: .infinity, minHeight: 40)
+                    }
+                }
+
+                Section("hig.right-to-left.interface.motion.title") {
+                    ForEach(layoutDirectionContexts) { layoutDirectionContexts in
+                        GroupBox {
+                            HStack {
+                                Image(systemName: "speaker.wave.3.fill")
+                                    .environment(\.layoutDirection, layoutDirectionContexts.layoutDirection)
+                            }
+                        } label: {
+                            Text(layoutDirectionContexts.description)
+                        }
+                    }
+                }
+
+                Section("hig.right-to-left.interface.backslash.title") {
+                    ForEach(layoutDirectionContexts) { layoutDirectionContexts in
+                        GroupBox {
+                            HStack {
+                                Image(systemName: "speaker.slash.fill")
+                                    .environment(\.layoutDirection, layoutDirectionContexts.layoutDirection)
+                            }
+                        } label: {
+                            Text(layoutDirectionContexts.description)
+                        }
+                    }
+                }
+
+                Section("hig.right-to-left.interface.component.title") {
+                    ForEach(layoutDirectionContexts) { layoutDirectionContexts in
+                        GroupBox {
+                            HStack {
+                                Image(systemName: "cart.fill.badge.plus")
+                                    .environment(\.layoutDirection, layoutDirectionContexts.layoutDirection)
+                            }
+                        } label: {
+                            Text(layoutDirectionContexts.description)
+                        }
+                    }
+                }
+
+                Section("hig.right-to-left.interface.tool.title") {
+                    ForEach(layoutDirectionContexts) { layoutDirectionContexts in
+                        GroupBox {
+                            HStack {
+                                Image(systemName: "mail.and.text.magnifyingglass")
+                                    .environment(\.layoutDirection, layoutDirectionContexts.layoutDirection)
+                            }
+                        } label: {
+                            Text(layoutDirectionContexts.description)
+                        }
+                    }
+                }
+            }
+            .padding()
+            .navigationBarTitle(
+                "hig.right-to-left.interface.title",
+                displayMode: .inline
+            )
         }
-        .padding()
-        ScrollView {
-            Section("hig.right-to-left.interface.directional.title") {
-                ForEach(layoutDirectionContexts) { layoutDirectionContexts in
-                    GroupBox {
-                        HStack {
-                            Image(systemName: "list.bullet")
-                                .environment(\.layoutDirection, layoutDirectionContexts.layoutDirection)
-                            Image(systemName: "book.closed")
-                                .environment(\.layoutDirection, layoutDirectionContexts.layoutDirection)
-                            Image(systemName: "rectangle.and.pencil.and.ellipsis")
-                                .environment(\.layoutDirection, layoutDirectionContexts.layoutDirection)
-                            Image(systemName: "macwindow")
-                                .environment(\.layoutDirection, layoutDirectionContexts.layoutDirection)
-                            Image(systemName: "battery.25percent")
-                                .environment(\.layoutDirection, layoutDirectionContexts.layoutDirection)
-                        }
-                    } label: {
-                        Text(layoutDirectionContexts.description)
-                    }
-                }
-            }
-
-            Section("hig.right-to-left.interface.text.title") {
-                ForEach(layoutDirectionContexts) { layoutDirectionContexts in
-                    GroupBox {
-                        HStack {
-                            Image(systemName: "text.page")
-                                .environment(\.layoutDirection, layoutDirectionContexts.layoutDirection)
-                        }
-                    } label: {
-                        Text(layoutDirectionContexts.description)
-                    }
-                }
-            }
-
-            Section("hig.right-to-left.interface.localized.title") {
-                ForEach(localeContexts) { localeContext in
-                    GroupBox {
-                        HStack {
-                            Image(systemName: "signature")
-                            Image(systemName: "richtext.page")
-                            Image(systemName: "character.cursor.ibeam")
-                        }
-                        .environment(\.locale, localeContext.locale)
-                    } label: {
-                        Text(localeContext.description)
-                    }
-                }
-            }
-
-            Section("hig.right-to-left.interface.motion.title") {
-                ForEach(layoutDirectionContexts) { layoutDirectionContexts in
-                    GroupBox {
-                        HStack {
-                            Image(systemName: "speaker.wave.3.fill")
-                                .environment(\.layoutDirection, layoutDirectionContexts.layoutDirection)
-                        }
-                    } label: {
-                        Text(layoutDirectionContexts.description)
-                    }
-                }
-            }
-
-            Section("hig.right-to-left.interface.backslash.title") {
-                ForEach(layoutDirectionContexts) { layoutDirectionContexts in
-                    GroupBox {
-                        HStack {
-                            Image(systemName: "speaker.slash.fill")
-                                .environment(\.layoutDirection, layoutDirectionContexts.layoutDirection)
-                        }
-                    } label: {
-                        Text(layoutDirectionContexts.description)
-                    }
-                }
-            }
-
-            Section("hig.right-to-left.interface.component.title") {
-                ForEach(layoutDirectionContexts) { layoutDirectionContexts in
-                    GroupBox {
-                        HStack {
-                            Image(systemName: "cart.fill.badge.plus")
-                                .environment(\.layoutDirection, layoutDirectionContexts.layoutDirection)
-                        }
-                    } label: {
-                        Text(layoutDirectionContexts.description)
-                    }
-                }
-            }
-
-            Section("hig.right-to-left.interface.tool.title") {
-                ForEach(layoutDirectionContexts) { layoutDirectionContexts in
-                    GroupBox {
-                        HStack {
-                            Image(systemName: "mail.and.text.magnifyingglass")
-                                .environment(\.layoutDirection, layoutDirectionContexts.layoutDirection)
-                        }
-                    } label: {
-                        Text(layoutDirectionContexts.description)
-                    }
-                }
-            }
-        }.padding()
     }
 }
 

--- a/SampleViewer/View/LanguageSpecificSFSymbolView.swift
+++ b/SampleViewer/View/LanguageSpecificSFSymbolView.swift
@@ -1,0 +1,98 @@
+import SwiftUI
+
+struct LanguageSpecificSFSymbolView: View {
+    private var languages = [
+        Language(
+            id: UUID(),
+            locale: .enUS,
+            description: "locale.en_US"
+        ),
+        Language(
+            id: UUID(),
+            locale: .arAE,
+            description: "locale.ar_AE"
+        ),
+        Language(
+            id: UUID(),
+            locale: .heIL,
+            description: "locale.he_IL"
+        ),
+        Language(
+            id: UUID(),
+            locale: .hiIN,
+            description: "locale.hi_IN"
+        ),
+        Language(
+            id: UUID(),
+            locale: .thTH,
+            description: "locale.th_TH"
+        ),
+        Language(
+            id: UUID(),
+            locale: .zhCN,
+            description: "locale.zh_CN"
+        ),
+        Language(
+            id: UUID(),
+            locale: .jaJP,
+            description: "locale.ja_JP"
+        ),
+        Language(
+            id: UUID(),
+            locale: .koKR,
+            description: "locale.ko_KR"
+        ),
+    ]
+
+    var body: some View {
+        NavigationStack {
+            Text("hig.sf-symbols.variant.language-specific.description")
+                .font(.body)
+
+            ScrollView {
+                ForEach(languages) { language in
+                    GroupBox(language.description) {
+                        HStack {
+                            Image(systemName: "richtext.page")
+                            Image(systemName: "richtext.page.fill")
+                            Image(systemName: "character.book.closed")
+                            Image(systemName: "character.book.closed.fill")
+                            Image(systemName: "character.bubble")
+                            Image(systemName: "character.bubble.fill")
+                            Image(systemName: "character")
+                            Image(systemName: "textformat.superscript")
+                            Image(systemName: "textformat.subscript")
+                            Image(systemName: "textformat.size")
+                            Image(systemName: "character.textbox")
+                            Image(systemName: "character.cursor.ibeam")
+                        }
+                        .environment(\.locale, language.locale)
+                    }
+                }
+            }
+            .navigationBarTitle(
+                "hig.sf-symbols.variant.language-specific.title",
+                displayMode: .inline
+            )
+        }
+        .padding()
+    }
+}
+
+private struct Language: Identifiable {
+    var id: UUID
+    var locale: Locale
+    var description: LocalizedStringKey
+}
+
+// MARK: - Xcode Preview
+
+#Preview("LanguageSpecificSFSymbolView(locale=enUS)") {
+    LanguageSpecificSFSymbolView()
+        .environment(\.locale, .enUS)
+}
+
+#Preview("LanguageSpecificSFSymbolView(locale=jaJP)") {
+    LanguageSpecificSFSymbolView()
+        .environment(\.locale, .jaJP)
+}


### PR DESCRIPTION
Closes #62 

# Changes

- Package/Sources/Localization/Locale.swift, Package/Tests/LocalizationTests/LocaleTest.swift
    - Add some locales
        - `hi_IN`: Hindi
        - `th_TH`: Thai
        - `zh_CN`: Chinese
        - `ko_KR`: Korean
- SampleViewer/Localizable.xcstrings
    - Add description texts on the sample
- SampleViewer/View/InterfaceIconView.swift
    - Add navigation title
    - Add "see more" button to open LanguageSpecificSFSymbolView.
- SampleViewer/View/LanguageSpecificSFSymbolView.swift
    - Add the sample view

Note:

- This sample view on the HIG page didn't contain Cyrillic (キリル文字).

# Screenshots

||enUS|jaJP|
|---|---|---|
|InterfaceIconView|<img src=https://github.com/user-attachments/assets/032d5895-d374-4933-8223-c2e0b4774650 width=200>|<img src=https://github.com/user-attachments/assets/5afd23e9-1067-40b3-a288-f444369ee2b3 width=200>|
|LanguageSpecificSFSymbolView|<img src=https://github.com/user-attachments/assets/7e67007b-4ba8-4c0c-92d2-0955522eb435 width=200>|<img src=https://github.com/user-attachments/assets/bb68eec3-1e94-45bb-bc4f-97094d35af43 width=200>|