### PR TITLE
Add a sample view for SF Symbols Effect

### DIFF
--- a/SampleViewer/Localizable.xcstrings
+++ b/SampleViewer/Localizable.xcstrings
@@ -868,6 +868,244 @@
         }
       }
     },
+    "hig.sf-symbols.animations.appear.description" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Appear"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "表示"
+          }
+        }
+      }
+    },
+    "hig.sf-symbols.animations.bounce.description" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Bounce"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "バウンス"
+          }
+        }
+      }
+    },
+    "hig.sf-symbols.animations.breathe.description" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Breathe"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "呼吸"
+          }
+        }
+      }
+    },
+    "hig.sf-symbols.animations.description" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "SF Symbols provides a collection of expressive, configurable animations that enhance your interface and add vitality to your app. Symbol animations help communicate ideas, provide feedback in response to people’s actions, and signal changes in status or ongoing activities."
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "SF Symbolsには、表現力豊かで自在に設定できるアニメーションのコレクションが用意されています。アニメーションは、インターフェイスの魅力を高め、アプリに活気を与えるのに役立ちます。シンボルのアニメーションは、アイデアを伝えたり、ユーザの操作に応じたフィードバックを返したり、ステータスや進行中のアクティビティの変化を通知したりするのに便利です。"
+          }
+        }
+      }
+    },
+    "hig.sf-symbols.animations.disappear.description" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Disappear"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "非表示"
+          }
+        }
+      }
+    },
+    "hig.sf-symbols.animations.magic.description" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Magic Replace"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "マジック置換"
+          }
+        }
+      }
+    },
+    "hig.sf-symbols.animations.pulse.description" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Pulse"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "パルス"
+          }
+        }
+      }
+    },
+    "hig.sf-symbols.animations.replace.description" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Replace"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "置き換え"
+          }
+        }
+      }
+    },
+    "hig.sf-symbols.animations.rotate.description" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Rotate"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "回転"
+          }
+        }
+      }
+    },
+    "hig.sf-symbols.animations.scale.description" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Scale"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "スケール"
+          }
+        }
+      }
+    },
+    "hig.sf-symbols.animations.title" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Animations"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "アニメーション"
+          }
+        }
+      }
+    },
+    "hig.sf-symbols.animations.toggle.title" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Toggle to animate"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "アニメーションのトグルスイッチ"
+          }
+        }
+      }
+    },
+    "hig.sf-symbols.animations.variableColor.description" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Variable color"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "可変カラー"
+          }
+        }
+      }
+    },
+    "hig.sf-symbols.animations.wiggle.description" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Wiggle"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "揺れ"
+          }
+        }
+      }
+    },
     "hig.sf-symbols.rendering.description" : {
       "extractionState" : "manual",
       "localizations" : {

--- a/SampleViewer/View/SFSymbolEffectView.swift
+++ b/SampleViewer/View/SFSymbolEffectView.swift
@@ -1,0 +1,168 @@
+import SwiftUI
+
+struct SFSymbolEffectView: View {
+    @State private var isOn: Bool = false
+
+    var body: some View {
+        VStack {
+            Text("hig.sf-symbols.animations.title")
+                .font(.title)
+            Text("hig.sf-symbols.animations.description")
+                .font(.body)
+            Toggle("hig.sf-symbols.animations.toggle.title", isOn: $isOn)
+        }
+        .padding()
+
+        ScrollView {
+            GroupBox("hig.sf-symbols.animations.appear.description") {
+                HStack {
+                    Image(systemName: "antenna.radiowaves.left.and.right")
+                        .symbolEffect(.appear, isActive: !isOn)
+                    Image(systemName: "photo.stack")
+                        .transition(.symbolEffect(.appear))
+                        .symbolEffect(.appear, isActive: !isOn)
+                    Image(systemName: "waveform")
+                        .transition(.symbolEffect(.appear))
+                        .symbolEffect(.appear, isActive: !isOn)
+                }
+                .frame(maxWidth: .infinity, minHeight: 40)
+            }
+
+            GroupBox("hig.sf-symbols.animations.disappear.description") {
+                HStack {
+                    Image(systemName: "folder.badge.plus")
+                        .symbolEffect(.disappear, isActive: isOn)
+                    Image(systemName: "lightbulb.2")
+                        .symbolEffect(.disappear, isActive: isOn)
+                    Image(systemName: "bubble.left.and.bubble.right")
+                        .symbolEffect(.disappear, isActive: isOn)
+                }
+                .frame(maxWidth: .infinity, minHeight: 40)
+            }
+
+            GroupBox("hig.sf-symbols.animations.bounce.description") {
+                HStack {
+                    Image(systemName: "music.note.list")
+                        .symbolEffect(.bounce)
+                    // TODO: Add "HAHA" symbol
+                    Image(systemName: "livephoto")
+                        .symbolEffect(.bounce)
+                }
+                .frame(maxWidth: .infinity, minHeight: 40)
+            }
+
+            GroupBox("hig.sf-symbols.animations.scale.description") {
+                HStack {
+                    Image(systemName: "pip.exit")
+                        .symbolEffect(.scale.up, isActive: isOn)
+                    Image(systemName: "square.3.layers.3d")
+                        .symbolEffect(.scale.up, isActive: isOn)
+                    Image(systemName: "homepod.and.homepod.mini.fill")
+                        .symbolEffect(.scale.up, isActive: isOn)
+                        .symbolRenderingMode(.monochrome)
+                }
+                .frame(maxWidth: .infinity, minHeight: 40)
+            }
+
+            GroupBox("hig.sf-symbols.animations.pulse.description") {
+                HStack {
+                    Image(systemName: "airplay.video")
+                        .symbolRenderingMode(.hierarchical)
+                        .symbolEffect(.pulse)
+                    // TODO: Add "waveform + bubble + pause" symbol
+                    Image(systemName: "inset.filled.rectangle.and.person.filled")
+                        .symbolEffect(.pulse)
+                }
+                .frame(maxWidth: .infinity, minHeight: 40)
+            }
+
+            GroupBox("hig.sf-symbols.animations.variableColor.description") {
+                HStack {
+                    Image(systemName: "speaker.wave.3.fill")
+                        .symbolEffect(.variableColor)
+                    Image(systemName: "wifi")
+                        .symbolEffect(.variableColor)
+                    Image(systemName: "sprinkler.and.droplets.fill")
+                        .symbolEffect(.variableColor)
+                }
+                .frame(maxWidth: .infinity, minHeight: 40)
+            }
+
+            GroupBox("hig.sf-symbols.animations.replace.description") {
+                HStack {
+                    Image(systemName: isOn ? "list.bullet" : "square.grid.2x2")
+                        .contentTransition(.symbolEffect(.replace.downUp))
+                    Image(systemName: isOn ? "cloud.sun.fill" : "cloud.rain.fill")
+                        .contentTransition(.symbolEffect(.replace.upUp))
+                    Image(systemName: isOn ? "multiply.circle.fill": "microphone.fill")
+                        .contentTransition(.symbolEffect(.replace.offUp))
+                        .symbolRenderingMode(isOn ? .hierarchical : .monochrome)
+                }
+                .frame(maxWidth: .infinity, minHeight: 40)
+            }
+
+            GroupBox("hig.sf-symbols.animations.magic.description") {
+                HStack {
+                    Image(systemName: isOn ? "creditcard.trianglebadge.exclamationmark" : "creditcard")
+                        .contentTransition(.symbolEffect(.replace.magic(fallback: .downUp)))
+                    Image(systemName: isOn ? "microphone.slash" : "microphone")
+                        .contentTransition(.symbolEffect(.replace.magic(fallback: .downUp)))
+                    Image(systemName: isOn ? "person.crop.circle.badge.xmark" : "person.crop.circle.badge.checkmark")
+                        .contentTransition(.symbolEffect(.replace.magic(fallback: .downUp)))
+                }
+                .frame(maxWidth: .infinity, minHeight: 40)
+            }
+
+            GroupBox("hig.sf-symbols.animations.wiggle.description") {
+                HStack {
+                    Image(systemName: "digitalcrown.horizontal.press")
+                        .symbolEffect(.wiggle)
+                    // FIXME: Enable "photo.on.rectangle.angled" symbol to wiggle animation
+                    Image(systemName: "photo.on.rectangle.angled")
+                        .symbolEffect(.wiggle)
+                    Image(systemName: "car.top.lane.dashed.arrowtriangle.inward")
+                        .symbolEffect(.wiggle)
+                }
+                .frame(maxWidth: .infinity, minHeight: 40)
+            }
+
+            GroupBox("hig.sf-symbols.animations.breathe.description") {
+                HStack {
+                    Image(systemName: "waveform")
+                        .symbolEffect(.breathe)
+                    Image(systemName: "translate")
+                        .symbolEffect(.breathe)
+                    Image(systemName: "livephoto")
+                        .symbolEffect(.breathe)
+                }
+                .frame(maxWidth: .infinity, minHeight: 40)
+            }
+
+            GroupBox("hig.sf-symbols.animations.rotate.description") {
+                HStack {
+                    // FIXME: Enable "gear" symbol to wiggle animation
+                    Image(systemName: "gear")
+                        .symbolEffect(.rotate, value: isOn)
+                    // FIXME: Enable "fan.desk" symbol to wiggle animation
+                    Image(systemName: "fan.desk")
+                        .symbolEffect(.rotate, isActive: isOn)
+                    // TODO: Add a symbol like solar system
+                }
+                .frame(maxWidth: .infinity, minHeight: 40)
+            }
+        }
+        .padding()
+    }
+}
+
+// MARK: - Xcode Preview
+
+#Preview("SFSymbolEffectView(locale=enUS)") {
+    SFSymbolEffectView()
+        .environment(\.locale, .enUS)
+}
+
+#Preview("SFSymbolEffectView(locale=jaJP)") {
+    SFSymbolEffectView()
+        .environment(\.locale, .jaJP)
+}


### PR DESCRIPTION
Closes #31 

# Changes

- SampleViewer/Localizable.xcstrings
    - Add description texts
- SampleViewer/View/SFSymbolEffectView.swift
    - Add the sample view

# Screenshots

|enUS|jaJP|
|---|---|
|<img src=https://github.com/user-attachments/assets/a5955395-3293-4efb-b2a6-a58efa42bfeb width=200>|<img src=https://github.com/user-attachments/assets/7434d7a4-022c-4ea5-9fd3-d42b8a761a90 width=200>|
|<img src=https://github.com/user-attachments/assets/85bca47d-f747-485e-b42f-6a0fb6f1a786 width=200>|<img src=https://github.com/user-attachments/assets/31603a4d-4fab-4b88-a859-7fe79bc5ef32 width=200>|
|<img src=https://github.com/user-attachments/assets/4690d622-23a6-44fb-b2a6-4060c3c4cb85 width=200>|<img src=https://github.com/user-attachments/assets/ef535d44-dfda-4faa-8663-e5ae30dc57a8 width=200>|

https://github.com/user-attachments/assets/71730cea-5dd9-428c-87b7-3933dcef60ae