### PR TITLE
Add a sample view for font size

### DIFF
--- a/SampleViewer/Localizable.xcstrings
+++ b/SampleViewer/Localizable.xcstrings
@@ -1344,6 +1344,40 @@
         }
       }
     },
+    "hig.typography.size.description" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Use font sizes that most people can read easily. For example, aim to use the minimum font size of 11 pt in iOS and iPadOS, 10 pt in macOS, 23 pt in tvOS, and 12 pt in visionOS and watchOS. It’s important to recognize that differences in device displays, including pixel density and brightness, in addition to other factors — such as ambient lighting, the reader’s proximity to the text, their visual acuity, and whether they’re in motion — can all impact legibility."
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "ほとんどの人が簡単に読めるフォントサイズを使用する。例えば、最小フォントサイズとしてiOSとiPadOSでは11 ptを、macOSでは10 ptを、tvOSでは23 ptを、visionOSとwatchOSでは12 ptを使用してください。ピクセル密度や輝度といったデバイスごとのディスプレイの違いに加えて、その他の要因（周囲の照明条件、読み手とテキストの近さ、読み手の視力、読み手が動いているかどうかなど）がすべて読みやすさに影響すると認識することが大切です。"
+          }
+        }
+      }
+    },
+    "hig.typography.size.title" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Font size"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "フォントサイズ"
+          }
+        }
+      }
+    },
     "locale.ar_AE" : {
       "extractionState" : "manual",
       "localizations" : {

--- a/SampleViewer/View/FontSizeView.swift
+++ b/SampleViewer/View/FontSizeView.swift
@@ -1,0 +1,49 @@
+import SwiftUI
+
+struct FontSizeView: View {
+    var body: some View {
+        VStack {
+            Text("hig.typography.size.title")
+                .font(.title)
+            Text("hig.typography.size.description")
+                .font(.system(size: 11))
+        }
+        .padding()
+
+        VStack {
+            Text(verbatim: "title")
+                .font(.title)
+            Text(verbatim: "title2")
+                .font(.title2)
+            Text(verbatim: "title3")
+                .font(.title3)
+            Text(verbatim: "headline")
+                .font(.headline)
+            Text(verbatim: "subheadline")
+                .font(.subheadline)
+            Text(verbatim: "body")
+                .font(.body)
+            Text(verbatim: "callout")
+                .font(.callout)
+            Text(verbatim: "footnote")
+                .font(.footnote)
+            Text(verbatim: "caption")
+                .font(.caption)
+            Text(verbatim: "caption2")
+                .font(.caption2)
+        }
+        .padding()
+    }
+}
+
+// MARK: - Xcode Preview
+
+#Preview("FontSizeView(locale=enUS)") {
+    FontSizeView()
+        .environment(\.locale, .enUS)
+}
+
+#Preview("FontSizeView(locale=jaJP)") {
+    FontSizeView()
+        .environment(\.locale, .jaJP)
+}


### PR DESCRIPTION
Closes #32 

# Changes

- SampleViewer/Localizable.xcstrings
    - Add description texts
- SampleViewer/View/FontSizeView.swift
    - Add the sample view

# Screenshots

|enUS|jaJP|
|---|--|
|<img src=https://github.com/user-attachments/assets/4551ddbc-e8ee-40d8-90a8-3d75e4321640 width=200>|<img src=https://github.com/user-attachments/assets/67dcf7b7-7df1-4b91-b198-83373bfd6095 width=200>|
