### PR TITLE
Add a sample view for font weights

### DIFF
--- a/SampleViewer/Localizable.xcstrings
+++ b/SampleViewer/Localizable.xcstrings
@@ -18,6 +18,159 @@
         }
       }
     },
+    "font-weight.black" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Black"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "ブラック"
+          }
+        }
+      }
+    },
+    "font-weight.bold" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Bold"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "ボールド"
+          }
+        }
+      }
+    },
+    "font-weight.heavy" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Heavy"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "ヘビー"
+          }
+        }
+      }
+    },
+    "font-weight.light" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Light"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "ライト"
+          }
+        }
+      }
+    },
+    "font-weight.medium" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Medium"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "ミディアム"
+          }
+        }
+      }
+    },
+    "font-weight.regular" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Regular"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "レギュラー"
+          }
+        }
+      }
+    },
+    "font-weight.semibold" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Semibold"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "セミボールド"
+          }
+        }
+      }
+    },
+    "font-weight.thin" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Thin"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "シン"
+          }
+        }
+      }
+    },
+    "font-weight.ultralight" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ultralight"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "ウルトラライト"
+          }
+        }
+      }
+    },
     "hig.accessibility.controls.configuration.description" : {
       "extractionState" : "manual",
       "localizations" : {
@@ -1340,6 +1493,40 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "ウェイト"
+          }
+        }
+      }
+    },
+    "hig.typography.font-weight.description" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "In general, avoid light font weights. For example, if you’re using system-provided fonts, prefer Regular, Medium, Semibold, or Bold font weights, and avoid Ultralight, Thin, and Light font weights, which can be difficult to see, especially when text is small."
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "通常はフォントのライトウェイトを避ける。例えば、システムで提供されるフォントを使用する場合は、レギュラー、ミディアム、セミボールド、またはボールドのフォントウェイトを優先的に使用し、特にテキストが小さい場合に読みづらくなりがちなウルトラライト、シン、ライトのフォントウェイトを避けてください。"
+          }
+        }
+      }
+    },
+    "hig.typography.font-weight.title" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Font weights"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "フォントウェイト"
           }
         }
       }

--- a/SampleViewer/View/FontWeightView.swift
+++ b/SampleViewer/View/FontWeightView.swift
@@ -1,0 +1,47 @@
+import SwiftUI
+
+struct FontWeightView: View {
+    var body: some View {
+        VStack {
+            Text("hig.typography.font-weight.title")
+                .font(.title)
+            Text("hig.typography.font-weight.description")
+                .font(.body)
+        }
+        .padding()
+
+        VStack {
+            Text("font-weight.ultralight")
+                .fontWeight(.ultraLight)
+            Text("font-weight.thin")
+                .fontWeight(.thin)
+            Text("font-weight.light")
+                .fontWeight(.light)
+            Text("font-weight.regular")
+                .fontWeight(.regular)
+            Text("font-weight.medium")
+                .fontWeight(.medium)
+            Text("font-weight.semibold")
+                .fontWeight(.semibold)
+            Text("font-weight.bold")
+                .fontWeight(.bold)
+            Text("font-weight.heavy")
+                .fontWeight(.heavy)
+            Text("font-weight.black")
+                .fontWeight(.black)
+        }
+        .padding()
+    }
+}
+
+// MARK: - Xcode Preview
+
+#Preview("FontWeightView(locale=enUS)") {
+    FontWeightView()
+        .environment(\.locale, .enUS)
+}
+
+#Preview("FontWeightView(locale=jaJP)") {
+    FontWeightView()
+        .environment(\.locale, .jaJP)
+}


### PR DESCRIPTION
Closes #33 

# Changes

- SampleViewer/Localizable.xcstrings
    - Add description texts
- SampleViewer/View/FontWeightView.swift
    - Add the sample view

# Screenshots

|enUS|jaJP|
|---|---|
|<img src=https://github.com/user-attachments/assets/39f1d5d8-ac57-4179-b46c-18fc76f0344f width=200>|<img src=https://github.com/user-attachments/assets/613453ae-6d7d-4034-adae-39db235b7c22 width=200>|
