### PR TITLE
Mark `sample.label` as translated

### DIFF
--- a/SampleViewer/Localizable.xcstrings
+++ b/SampleViewer/Localizable.xcstrings
@@ -1848,7 +1848,7 @@
         },
         "ja" : {
           "stringUnit" : {
-            "state" : "needs_review",
+            "state" : "translated",
             "value" : "ラベル"
           }
         }


### PR DESCRIPTION
Closes #73 

# Changes

- SampleViewer/Localizable.xcstrings
    - Mark  `sample.label` as translated