### PR TITLE
Add a sample view of trend detail chart

### DIFF
--- a/SampleViewer/Localizable.xcstrings
+++ b/SampleViewer/Localizable.xcstrings
@@ -545,6 +545,227 @@
         }
       }
     },
+    "hig.charting-data.trend-detail.chart.scale.description" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Scale"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "スケール"
+          }
+        }
+      }
+    },
+    "hig.charting-data.trend-detail.chart.title" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "DAILY AVERAGE"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "1日の平均"
+          }
+        }
+      }
+    },
+    "hig.charting-data.trend-detail.domain.description%@%@" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%@ – %@"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%@〜%@"
+          }
+        }
+      }
+    },
+    "hig.charting-data.trend-detail.segmented.daily.accessibility.label" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Day"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "日"
+          }
+        }
+      }
+    },
+    "hig.charting-data.trend-detail.segmented.daily.description" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "D"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "日"
+          }
+        }
+      }
+    },
+    "hig.charting-data.trend-detail.segmented.half-yearly.accessibility.label" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "6 months"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "六か月"
+          }
+        }
+      }
+    },
+    "hig.charting-data.trend-detail.segmented.half-yearly.description" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "6 M"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "6ヶ月"
+          }
+        }
+      }
+    },
+    "hig.charting-data.trend-detail.segmented.monthly.accessibility.label" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Month"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "月"
+          }
+        }
+      }
+    },
+    "hig.charting-data.trend-detail.segmented.monthly.description" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "M"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "月"
+          }
+        }
+      }
+    },
+    "hig.charting-data.trend-detail.segmented.weekly.accessibility.label" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Week"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "週"
+          }
+        }
+      }
+    },
+    "hig.charting-data.trend-detail.segmented.weekly.description" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "W"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "週"
+          }
+        }
+      }
+    },
+    "hig.charting-data.trend-detail.segmented.yearly.accessibility.label" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Year"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "年"
+          }
+        }
+      }
+    },
+    "hig.charting-data.trend-detail.segmented.yearly.description" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Y"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "年"
+          }
+        }
+      }
+    },
     "hig.charting-data.trend.chart.accessibility.value" : {
       "extractionState" : "manual",
       "localizations" : {
@@ -558,6 +779,38 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "トレンドの図表"
+          }
+        }
+      }
+    },
+    "hig.charting-data.trend.chart.bar.accessibility.label%@" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%@."
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%@。"
+          }
+        }
+      }
+    },
+    "hig.charting-data.trend.chart.bar.accessibility.value%lld" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Steps. Daily average. %lld steps."
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "歩数。1日の平均。%lld歩。"
           }
         }
       }
@@ -2171,6 +2424,23 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "タイトル"
+          }
+        }
+      }
+    },
+    "unit.steps" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : " steps"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "歩"
           }
         }
       }

--- a/SampleViewer/View/ChartTrendDetailView.swift
+++ b/SampleViewer/View/ChartTrendDetailView.swift
@@ -1,0 +1,237 @@
+import SwiftUI
+import Charts
+
+struct ChartTrendDetailView: View {
+    @Environment(\.locale) private var locale: Locale
+    @Environment(\.timeZone) private var timeZone: TimeZone
+
+    // TODO: Generate daily step log
+    @State
+    private var steps: [Step] = [
+        2585,
+        2161,
+        1427,
+        3085,
+        1323,
+        2036,
+        2290,
+        3750,
+        3667,
+        1132,
+        4630,
+        1692,
+        1187,
+        1214,
+        4269,
+        4033,
+        4909,
+        4915,
+        2480,
+        1321,
+        3333,
+        1029,
+        3163,
+        2821,
+        1666,
+    ]
+    .enumerated()
+    .map { index, numberOfSteps in
+        Step(
+            id: UUID(),
+            date: Date(
+                timeIntervalSince1970: 1704207600 // 2024-01-03T00:00:00+09:00
+                + TimeInterval(60 * 60 * 24 * 7 * index) // 1 week
+            ),
+            numberOfSteps: numberOfSteps
+        )
+    }
+
+    // TODO: Support other stride types
+    @State
+    private var scale = Scale.halfYearly
+
+    var body: some View {
+        // TODO: Calculate daily average, not weekly average
+        let averageOfSteps =
+            steps.isEmpty ? 0 : steps.reduce(0) { $0 + $1.numberOfSteps } / steps.count
+
+        VStack {
+            Picker("hig.charting-data.trend-detail.chart.scale.description", selection: $scale) {
+                ForEach(Scale.allCases) {
+                    Text($0.localizedString)
+                        // FIXME: Enable accessibility label
+                        .accessibilityLabel(Text($0.accessibilityLocalizedString))
+                }
+            }
+            .pickerStyle(.segmented)
+
+            // FIXME: Accessibility area
+            VStack(alignment: .leading) {
+                Text("hig.charting-data.trend-detail.chart.title")
+                    .foregroundStyle(Color.gray)
+                    .font(.subheadline)
+                Text(averageOfSteps.formatted())
+                    .font(.system(.largeTitle))
+                +
+                Text("unit.steps")
+                    .foregroundStyle(Color.gray)
+                domainText()
+                    .foregroundStyle(Color.gray)
+            }
+            .frame(maxWidth: .infinity, alignment: .leading)
+            // FIXME: Remove "てん" from text in ja_JP
+            .accessibilityElement(children: .combine)
+
+            Chart {
+                ForEach(steps) { step in
+                    BarMark(
+                        x: .value("hig.charting-data.trend.chart.week.description", step.date),
+                        y: .value("hig.charting-data.trend.chart.step.description", step.numberOfSteps)
+                    )
+                    .foregroundStyle(Color.gray)
+                    .accessibilityLabel(
+                        "hig.charting-data.trend.chart.bar.accessibility.label\(step.date.formatted(localizedDateFormatStyle().month().day()))"
+                    )
+                    .accessibilityValue(
+                        "hig.charting-data.trend.chart.bar.accessibility.value\(averageOfSteps)"
+                    )
+                }
+
+                // TODO: Hides this rule mark after tapping a picker button
+                if let minimumOfDate = steps.map({ $0.date }).min(),
+                   let maximumOfDate = steps.map({ $0.date }).max() {
+                    RuleMark(
+                        xStart: .value("hig.charting-data.trend.chart.week.description", minimumOfDate),
+                        xEnd: .value("hig.charting-data.trend.chart.week.description", maximumOfDate),
+                        y: .value("hig.charting-data.trend.chart.step.description", averageOfSteps)
+                    )
+                    .foregroundStyle(Color.red)
+                    .lineStyle(StrokeStyle(lineWidth: 5, lineCap: .round))
+                    .annotation(position: .top, alignment: .trailing) {
+                         Text("unit.steps\(averageOfSteps)")
+                            .foregroundStyle(Color.red)
+                    }
+                }
+            }
+            .chartXAxis {
+                // TODO: Configure stride for each scale
+                AxisMarks(values: .stride(by: .month, count: 1)) { value in
+                    if let date = value.as(Date.self) {
+                        // TODO: Show labels correctly
+                        AxisValueLabel {
+                            switch scale {
+                            case .daily:
+                                Text(date, format: localizedDateFormatStyle().hour())
+                            case .weekly:
+                                Text(date, format: localizedDateFormatStyle().week())
+                            case .monthly:
+                                Text(date, format: localizedDateFormatStyle().day())
+                            case .halfYearly, .yearly:
+                                Text(date, format: localizedDateFormatStyle().month(.abbreviated))
+                            }
+                        }
+
+                        AxisGridLine()
+                        AxisTick()
+                    }
+                }
+            }
+            .chartYAxis {
+                AxisMarks(values: .automatic(desiredCount: numberOfYAxisMarks()))
+            }
+            .frame(height: 300)
+        }
+        .padding()
+    }
+
+    private func numberOfYAxisMarks() -> Int {
+        switch scale {
+        case .daily, .weekly, .monthly: 4
+        case .halfYearly, .yearly: 3
+        }
+    }
+
+    private func domainText() -> Text? {
+        let dates = steps.sorted { $0.date < $1.date }.map(\.date)
+        guard let startDate = dates.first, let endDate = dates.last else {
+            return nil
+        }
+
+        let yearFormatStyle = localizedDateFormatStyle().year()
+        let isAcrossYears = startDate.formatted(yearFormatStyle) != endDate.formatted(yearFormatStyle)
+
+        let hasYearPrefix =
+            switch locale {
+            case .jaJP:
+                true
+            case .enUS:
+                false
+            default:
+                false
+            }
+        let hasYearSuffix = !hasYearPrefix
+
+        let formatStyle = localizedDateFormatStyle().month().day()
+        let startFormatStyle = isAcrossYears || hasYearPrefix ? formatStyle.year() : formatStyle
+        let endFormatStyle = isAcrossYears || hasYearSuffix ? formatStyle.year() : formatStyle
+        return Text("hig.charting-data.trend-detail.domain.description\(startDate.formatted(startFormatStyle))\(endDate.formatted(endFormatStyle))")
+    }
+
+    private func localizedDateFormatStyle() -> Date.FormatStyle {
+        var formatStyle = Date.FormatStyle.dateTime.locale(locale)
+        formatStyle.timeZone = timeZone
+        return formatStyle
+    }
+}
+
+private enum Scale: CaseIterable {
+    case daily
+    case weekly
+    case monthly
+    case halfYearly
+    case yearly
+
+    var localizedString: LocalizedStringKey {
+        switch self {
+        case .daily: "hig.charting-data.trend-detail.segmented.daily.description"
+        case .weekly: "hig.charting-data.trend-detail.segmented.weekly.description"
+        case .monthly: "hig.charting-data.trend-detail.segmented.monthly.description"
+        case .halfYearly: "hig.charting-data.trend-detail.segmented.half-yearly.description"
+        case .yearly: "hig.charting-data.trend-detail.segmented.yearly.description"
+        }
+    }
+
+    var accessibilityLocalizedString: LocalizedStringKey {
+        switch self {
+        case .daily: "hig.charting-data.trend-detail.segmented.daily.accessibility.label"
+        case .weekly: "hig.charting-data.trend-detail.segmented.weekly.accessibility.label"
+        case .monthly: "hig.charting-data.trend-detail.segmented.monthly.accessibility.label"
+        case .halfYearly: "hig.charting-data.trend-detail.segmented.half-yearly.accessibility.label"
+        case .yearly: "hig.charting-data.trend-detail.segmented.yearly.accessibility.label"
+        }
+    }
+}
+
+extension Scale: Identifiable {
+    var id: Self { self }
+}
+
+private struct Step: Identifiable {
+    var id: UUID
+    var date: Date
+    var numberOfSteps: Int
+}
+
+// MARK: - Xcode Preview
+
+#Preview("ChartTrendDetailView(locale=enUS,timeZone=losAngeles)") {
+    ChartTrendDetailView()
+        .environment(\.timeZone, .losAngeles)
+        .environment(\.locale, .enUS)
+}
+
+#Preview("ChartTrendDetailView(locale=jaJP,timeZone=tokyo)") {
+    ChartTrendDetailView()
+        .environment(\.timeZone, .tokyo)
+        .environment(\.locale, .jaJP)
+}


### PR DESCRIPTION
Closes #87 

# Changes

- SampleViewer/Localizable.xcstrings
    - Add description texts
- SampleViewer/View/ChartTrendDetailView.swift
    - Add the sample view

# Screenshots

|enUS|jaJP|
|---|---|
|<img src=https://github.com/user-attachments/assets/7c70f9df-0aec-4782-b62a-7d0954eb3ba7 width=200>|<img src=https://github.com/user-attachments/assets/0c004e93-9250-4121-91c6-e132df16c487 width=200>|
