### PR TITLE
Implement transition from ChartTrendView to ChartTrendDetailView

### DIFF
--- a/SampleViewer/Assets.xcassets/Sample Colors/hig.charting-data.trend.box.background.colorset/Contents.json
+++ b/SampleViewer/Assets.xcassets/Sample Colors/hig.charting-data.trend.box.background.colorset/Contents.json
@@ -1,0 +1,38 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0xFF",
+          "green" : "0xFF",
+          "red" : "0xFF"
+        }
+      },
+      "idiom" : "universal"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "dark"
+        }
+      ],
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0x1E",
+          "green" : "0x1C",
+          "red" : "0x1D"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/SampleViewer/Localizable.xcstrings
+++ b/SampleViewer/Localizable.xcstrings
@@ -596,6 +596,23 @@
         }
       }
     },
+    "hig.charting-data.trend-detail.navigation.title" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Steps"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "歩数"
+          }
+        }
+      }
+    },
     "hig.charting-data.trend-detail.segmented.daily.accessibility.label" : {
       "extractionState" : "manual",
       "localizations" : {
@@ -877,6 +894,23 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "ユーザが1つのデータセットをさまざまな視点から探索できるように複数のグラフを用意する場合、グラフの種類を1つに限定し、一貫した色、注釈、レイアウト、説明となるテキストを使用して、同じデータセットを一貫して対象にしているという視覚効果を保つのは大切です。"
+          }
+        }
+      }
+    },
+    "hig.charting-data.trend.navigation.title" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Trends"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "トレンド"
           }
         }
       }

--- a/SampleViewer/View/ChartTrendDetailView.swift
+++ b/SampleViewer/View/ChartTrendDetailView.swift
@@ -55,91 +55,95 @@ struct ChartTrendDetailView: View {
         let averageOfSteps =
             steps.isEmpty ? 0 : steps.reduce(0) { $0 + $1.numberOfSteps } / steps.count
 
-        VStack {
-            Picker("hig.charting-data.trend-detail.chart.scale.description", selection: $scale) {
-                ForEach(Scale.allCases) {
-                    Text($0.localizedString)
-                        // FIXME: Enable accessibility label
-                        .accessibilityLabel(Text($0.accessibilityLocalizedString))
-                }
-            }
-            .pickerStyle(.segmented)
-
-            // FIXME: Accessibility area
-            VStack(alignment: .leading) {
-                Text("hig.charting-data.trend-detail.chart.title")
-                    .foregroundStyle(Color.gray)
-                    .font(.subheadline)
-                Text(averageOfSteps.formatted())
-                    .font(.system(.largeTitle))
-                +
-                Text("unit.steps")
-                    .foregroundStyle(Color.gray)
-                domainText()
-                    .foregroundStyle(Color.gray)
-            }
-            .frame(maxWidth: .infinity, alignment: .leading)
-            // FIXME: Remove "てん" from text in ja_JP
-            .accessibilityElement(children: .combine)
-
-            Chart {
-                ForEach(steps) { step in
-                    BarMark(
-                        x: .value("hig.charting-data.trend.chart.week.description", step.date),
-                        y: .value("hig.charting-data.trend.chart.step.description", step.numberOfSteps)
-                    )
-                    .foregroundStyle(Color.gray)
-                    .accessibilityLabel(
-                        "hig.charting-data.trend.chart.bar.accessibility.label\(step.date.formatted(localizedDateFormatStyle().month().day()))"
-                    )
-                    .accessibilityValue(
-                        "hig.charting-data.trend.chart.bar.accessibility.value\(averageOfSteps)"
-                    )
-                }
-
-                // TODO: Hides this rule mark after tapping a picker button
-                if let minimumOfDate = steps.map({ $0.date }).min(),
-                   let maximumOfDate = steps.map({ $0.date }).max() {
-                    RuleMark(
-                        xStart: .value("hig.charting-data.trend.chart.week.description", minimumOfDate),
-                        xEnd: .value("hig.charting-data.trend.chart.week.description", maximumOfDate),
-                        y: .value("hig.charting-data.trend.chart.step.description", averageOfSteps)
-                    )
-                    .foregroundStyle(Color.red)
-                    .lineStyle(StrokeStyle(lineWidth: 5, lineCap: .round))
-                    .annotation(position: .top, alignment: .trailing) {
-                         Text("unit.steps\(averageOfSteps)")
-                            .foregroundStyle(Color.red)
+        NavigationStack {
+            VStack {
+                Picker("hig.charting-data.trend-detail.chart.scale.description", selection: $scale) {
+                    ForEach(Scale.allCases) {
+                        Text($0.localizedString)
+                            // FIXME: Enable accessibility label
+                            .accessibilityLabel(Text($0.accessibilityLocalizedString))
                     }
                 }
-            }
-            .chartXAxis {
-                // TODO: Configure stride for each scale
-                AxisMarks(values: .stride(by: .month, count: 1)) { value in
-                    if let date = value.as(Date.self) {
-                        // TODO: Show labels correctly
-                        AxisValueLabel {
-                            switch scale {
-                            case .daily:
-                                Text(date, format: localizedDateFormatStyle().hour())
-                            case .weekly:
-                                Text(date, format: localizedDateFormatStyle().week())
-                            case .monthly:
-                                Text(date, format: localizedDateFormatStyle().day())
-                            case .halfYearly, .yearly:
-                                Text(date, format: localizedDateFormatStyle().month(.abbreviated))
-                            }
+                .pickerStyle(.segmented)
+
+                // FIXME: Accessibility area
+                VStack(alignment: .leading) {
+                    Text("hig.charting-data.trend-detail.chart.title")
+                        .foregroundStyle(Color.gray)
+                        .font(.subheadline)
+                    Text(averageOfSteps.formatted())
+                        .font(.system(.largeTitle))
+                    +
+                    Text("unit.steps")
+                        .foregroundStyle(Color.gray)
+                    domainText()
+                        .foregroundStyle(Color.gray)
+                }
+                .frame(maxWidth: .infinity, alignment: .leading)
+                // FIXME: Remove "てん" from text in ja_JP
+                .accessibilityElement(children: .combine)
+
+                Chart {
+                    ForEach(steps) { step in
+                        BarMark(
+                            x: .value("hig.charting-data.trend.chart.week.description", step.date),
+                            y: .value("hig.charting-data.trend.chart.step.description", step.numberOfSteps)
+                        )
+                        .foregroundStyle(Color.gray)
+                        .accessibilityLabel(
+                            "hig.charting-data.trend.chart.bar.accessibility.label\(step.date.formatted(localizedDateFormatStyle().month().day()))"
+                        )
+                        .accessibilityValue(
+                            "hig.charting-data.trend.chart.bar.accessibility.value\(averageOfSteps)"
+                        )
+                    }
+
+                    // TODO: Hides this rule mark after tapping a picker button
+                    if let minimumOfDate = steps.map({ $0.date }).min(),
+                       let maximumOfDate = steps.map({ $0.date }).max() {
+                        RuleMark(
+                            xStart: .value("hig.charting-data.trend.chart.week.description", minimumOfDate),
+                            xEnd: .value("hig.charting-data.trend.chart.week.description", maximumOfDate),
+                            y: .value("hig.charting-data.trend.chart.step.description", averageOfSteps)
+                        )
+                        .foregroundStyle(Color.red)
+                        .lineStyle(StrokeStyle(lineWidth: 5, lineCap: .round))
+                        .annotation(position: .top, alignment: .trailing) {
+                            Text("unit.steps\(averageOfSteps)")
+                                .foregroundStyle(Color.red)
                         }
-
-                        AxisGridLine()
-                        AxisTick()
                     }
                 }
+                .chartXAxis {
+                    // TODO: Configure stride for each scale
+                    AxisMarks(values: .stride(by: .month, count: 1)) { value in
+                        if let date = value.as(Date.self) {
+                            // TODO: Show labels correctly
+                            AxisValueLabel {
+                                switch scale {
+                                case .daily:
+                                    Text(date, format: localizedDateFormatStyle().hour())
+                                case .weekly:
+                                    Text(date, format: localizedDateFormatStyle().week())
+                                case .monthly:
+                                    Text(date, format: localizedDateFormatStyle().day())
+                                case .halfYearly, .yearly:
+                                    Text(date, format: localizedDateFormatStyle().month(.abbreviated))
+                                }
+                            }
+
+                            AxisGridLine()
+                            AxisTick()
+                        }
+                    }
+                }
+                .chartYAxis {
+                    AxisMarks(values: .automatic(desiredCount: numberOfYAxisMarks()))
+                }
+                .frame(height: 300)
             }
-            .chartYAxis {
-                AxisMarks(values: .automatic(desiredCount: numberOfYAxisMarks()))
-            }
-            .frame(height: 300)
+            .navigationTitle("hig.charting-data.trend-detail.navigation.title")
+            .navigationBarTitleDisplayMode(.inline)
         }
         .padding()
     }

--- a/SampleViewer/View/ChartTrendView.swift
+++ b/SampleViewer/View/ChartTrendView.swift
@@ -48,68 +48,76 @@ struct ChartTrendView: View {
         let averageOfSteps =
             steps.isEmpty ? 0 : steps.reduce(0) { $0 + $1.numberOfSteps } / steps.count
 
-        VStack {
-            Text("hig.charting-data.trend.title")
-                .font(.title)
-            Text("hig.charting-data.trend.description")
-                .font(.body)
-        }
-        .padding()
-
-        GroupBox {
+        // TODO: Set background color to entire view
+        NavigationStack {
             VStack {
-                HStack {
-                    Image(systemName: "flame.fill")
-                        .foregroundStyle(Color.red)
-                    Text("hig.charting-data.trend.chart.title")
-                        .foregroundStyle(Color.red)
-                    Spacer()
-                    Image(systemName: "chevron.forward")
-                        .foregroundStyle(Color.gray)
-                }
-                .padding(.bottom)
-                Text("hig.charting-data.trend.summary.description\(steps.count)\(averageOfSteps)")
-                Divider()
-                Chart {
-                    ForEach(steps) { step in
-                        BarMark(
-                            x: .value("hig.charting-data.trend.chart.week.description", step.date),
-                            y: .value("hig.charting-data.trend.chart.step.description", step.numberOfSteps)
-                        )
-                        .foregroundStyle(Color.gray)
-                    }
-
-                    if let minimumOfDate = steps.map({ $0.date }).min(),
-                       let maximumOfDate = steps.map({ $0.date }).max() {
-                        RuleMark(
-                            xStart: .value("hig.charting-data.trend.chart.week.description", minimumOfDate),
-                            xEnd: .value("hig.charting-data.trend.chart.week.description", maximumOfDate),
-                            y: .value("hig.charting-data.trend.chart.step.description", averageOfSteps)
-                        )
-                        .foregroundStyle(Color.red)
-                        .lineStyle(StrokeStyle(lineWidth: 5, lineCap: .round))
-                        .annotation(position: .top, alignment: .leading) {
-                            Text("unit.steps\(averageOfSteps)")
-                                .foregroundStyle(Color.red)
-                        }
-                    }
-                }
-                .chartXAxis(.hidden)
-                .chartYAxis(.hidden)
-                .frame(height: 150)
-                .accessibilityLabel("hig.charting-data.trend.chart.accessibility.value")
-                Text("unit.weeks\(steps.count)")
-                    .foregroundStyle(Color.red)
-                    .frame(maxWidth: .infinity, alignment: .leading)
-                    .accessibilityHidden(true)
+                Text("hig.charting-data.trend.title")
+                    .font(.title)
+                Text("hig.charting-data.trend.description")
+                    .font(.body)
             }
-            // FIXME: Remove "てん" from text in ja_JP
-            .accessibilityElement(children: .combine)
-        }
-        .padding()
-        .onTapGesture {
-            // TODO: Move to detail view
-            print("tapped")
+            .padding()
+
+            VStack {
+                // FIXME: Highlight only background when a user taps
+                NavigationLink(destination: ChartTrendDetailView()) {
+                    VStack {
+                        HStack {
+                            Image(systemName: "flame.fill")
+                                .foregroundStyle(Color.red)
+                            Text("hig.charting-data.trend.chart.title")
+                                .foregroundStyle(Color.red)
+                            Spacer()
+                            Image(systemName: "chevron.forward")
+                                .foregroundStyle(Color.gray)
+                        }
+                        .padding(.bottom)
+                        Text("hig.charting-data.trend.summary.description\(steps.count)\(averageOfSteps)")
+                        Divider()
+                        Chart {
+                            ForEach(steps) { step in
+                                BarMark(
+                                    x: .value("hig.charting-data.trend.chart.week.description", step.date),
+                                    y: .value("hig.charting-data.trend.chart.step.description", step.numberOfSteps)
+                                )
+                                .foregroundStyle(Color.gray)
+                            }
+
+                            if let minimumOfDate = steps.map({ $0.date }).min(),
+                               let maximumOfDate = steps.map({ $0.date }).max() {
+                                RuleMark(
+                                    xStart: .value("hig.charting-data.trend.chart.week.description", minimumOfDate),
+                                    xEnd: .value("hig.charting-data.trend.chart.week.description", maximumOfDate),
+                                    y: .value("hig.charting-data.trend.chart.step.description", averageOfSteps)
+                                )
+                                .foregroundStyle(Color.red)
+                                .lineStyle(StrokeStyle(lineWidth: 5, lineCap: .round))
+                                .annotation(position: .top, alignment: .leading) {
+                                    Text("unit.steps\(averageOfSteps)")
+                                        .foregroundStyle(Color.red)
+                                }
+                            }
+                        }
+                        .chartXAxis(.hidden)
+                        .chartYAxis(.hidden)
+                        .frame(height: 150)
+                        .accessibilityLabel("hig.charting-data.trend.chart.accessibility.value")
+                        Text("unit.weeks\(steps.count)")
+                            .foregroundStyle(Color.red)
+                            .frame(maxWidth: .infinity, alignment: .leading)
+                            .accessibilityHidden(true)
+                    }
+                }
+                .buttonStyle(.plain)
+                // FIXME: Remove "てん" from text in ja_JP
+                .accessibilityElement(children: .combine)
+                .padding()
+                .background(Color("hig.charting-data.trend.box.background"))
+                .clipShape(RoundedRectangle(cornerRadius: 10))
+            }
+            .padding()
+            .navigationTitle("hig.charting-data.trend.navigation.title")
+            .navigationBarTitleDisplayMode(.inline)
         }
     }
 }
@@ -122,12 +130,20 @@ private struct Step: Identifiable {
 
 // MARK: - Xcode Preview
 
-#Preview("ChartTrendView(locale=enUS)") {
+#Preview("ChartTrendView(locale=enUS,colorScheme=light)") {
     ChartTrendView()
         .environment(\.locale, .enUS)
+        .environment(\.colorScheme, .light)
 }
 
-#Preview("ChartTrendView(locale=jaJP)") {
+#Preview("ChartTrendView(locale=enUS,colorScheme=dark)") {
+    ChartTrendView()
+        .environment(\.locale, .enUS)
+        .environment(\.colorScheme, .dark)
+}
+
+#Preview("ChartTrendView(locale=jaJP,colorScheme=light)") {
     ChartTrendView()
         .environment(\.locale, .jaJP)
+        .environment(\.colorScheme, .light)
 }


### PR DESCRIPTION
Closes #93 

# Changes

- SampleViewer/Assets.xcassets/Sample Colors/hig.charting-data.trend.box.background.colorset/Contents.json
    - Add a background color of trend box view

<img src=https://github.com/user-attachments/assets/10956ac7-e8be-4fe8-b03c-192df3c46028 width=200>

- SampleViewer/Localizable.xcstrings
    - Add navigation titles
- SampleViewer/View/ChartTrendDetailView.swift, SampleViewer/View/ChartTrendView.swift
    - Use `NavigationStack` and `NavigationLink`

# Screenshots

||enUS|jaJP|
|---|---|---|
|light|→|<img src=https://github.com/user-attachments/assets/9624fd6a-f4fb-41e9-adb9-5f25631dd2ee width=150>→<img src=https://github.com/user-attachments/assets/4efde477-5814-40d7-8aec-54a7e890c11b width=150>|
|dark|<img src=https://github.com/user-attachments/assets/da61206a-fc29-4697-8169-60570f63afda width=150>→<img src=https://github.com/user-attachments/assets/1ae5f9c7-bc5b-49fb-8940-087328cd5c08 width=150>|<img src=https://github.com/user-attachments/assets/fd0caa3f-e36a-4606-9f93-cab18c418f83 width=150>→<img src=https://github.com/user-attachments/assets/ac861218-7920-4222-8ca8-774d1091f33e width=150>|

Accessibility
<img src=https://github.com/user-attachments/assets/805227f8-640b-4bd5-a3f3-e13e75c3dc13 width=200>
