### PR TITLE
Set background color to the chart trend view

### DIFF
--- a/SampleViewer/Assets.xcassets/Sample Colors/hig.charting-data.trend.background.colorset/Contents.json
+++ b/SampleViewer/Assets.xcassets/Sample Colors/hig.charting-data.trend.background.colorset/Contents.json
@@ -1,0 +1,38 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0xF8",
+          "green" : "0xF2",
+          "red" : "0xF2"
+        }
+      },
+      "idiom" : "universal"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "dark"
+        }
+      ],
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0x00",
+          "green" : "0x00",
+          "red" : "0x00"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/SampleViewer/View/ChartTrendView.swift
+++ b/SampleViewer/View/ChartTrendView.swift
@@ -48,7 +48,6 @@ struct ChartTrendView: View {
         let averageOfSteps =
             steps.isEmpty ? 0 : steps.reduce(0) { $0 + $1.numberOfSteps } / steps.count
 
-        // TODO: Set background color to entire view
         NavigationStack {
             VStack {
                 Text("hig.charting-data.trend.title")
@@ -118,6 +117,7 @@ struct ChartTrendView: View {
             .padding()
             .navigationTitle("hig.charting-data.trend.navigation.title")
             .navigationBarTitleDisplayMode(.inline)
+            .background(Color("hig.charting-data.trend.background"))
         }
     }
 }


### PR DESCRIPTION
Closes #96 

# Changes

- SampleViewer/Assets.xcassets/Sample Colors/hig.charting-data.trend.background.colorset/Contents.json
    - Add a set of colors to use the same one as Health
- SampleViewer/View/ChartTrendView.swift
    - Set the color

# Screenshots

<img src=https://github.com/user-attachments/assets/ca7811e4-25cf-42d2-b6e3-7680094e786b width=200>
<img src=https://github.com/user-attachments/assets/2f2029c7-6995-43ba-b5c7-56f49b62f077 width=200>

