### PR TITLE
Fix accessibility label of chart picker

### DIFF
--- a/SampleViewer/Localizable.xcstrings
+++ b/SampleViewer/Localizable.xcstrings
@@ -659,7 +659,7 @@
         "ja" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "六か月"
+            "value" : "6か月"
           }
         }
       }
@@ -676,7 +676,7 @@
         "ja" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "6ヶ月"
+            "value" : "6か月"
           }
         }
       }

--- a/SampleViewer/View/ChartTrendDetailView.swift
+++ b/SampleViewer/View/ChartTrendDetailView.swift
@@ -60,7 +60,6 @@ struct ChartTrendDetailView: View {
                 Picker("hig.charting-data.trend-detail.chart.scale.description", selection: $scale) {
                     ForEach(Scale.allCases) {
                         Text($0.localizedString)
-                            // FIXME: Enable accessibility label
                             .accessibilityLabel(Text($0.accessibilityLocalizedString))
                     }
                 }


### PR DESCRIPTION
Closes #90 

# Changes

- SampleViewer/Localizable.xcstrings
    - VoiceOver cannot read "6ヶ月" correctly.
- SampleViewer/View/ChartTrendDetailView.swift
    - Delete TODO comment