### PR TITLE
Fix accessibility area of chart trend detail view

### DIFF
--- a/SampleViewer/Assets.xcassets/Sample Colors/hig.charting-data.trend-detail.background.colorset/Contents.json
+++ b/SampleViewer/Assets.xcassets/Sample Colors/hig.charting-data.trend-detail.background.colorset/Contents.json
@@ -1,0 +1,38 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0xFF",
+          "green" : "0xFF",
+          "red" : "0xFF"
+        }
+      },
+      "idiom" : "universal"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "dark"
+        }
+      ],
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0x00",
+          "green" : "0x00",
+          "red" : "0x00"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/SampleViewer/View/ChartTrendDetailView.swift
+++ b/SampleViewer/View/ChartTrendDetailView.swift
@@ -65,7 +65,6 @@ struct ChartTrendDetailView: View {
                 }
                 .pickerStyle(.segmented)
 
-                // FIXME: Accessibility area
                 VStack(alignment: .leading) {
                     Text("hig.charting-data.trend-detail.chart.title")
                         .foregroundStyle(Color.gray)
@@ -79,6 +78,8 @@ struct ChartTrendDetailView: View {
                         .foregroundStyle(Color.gray)
                 }
                 .frame(maxWidth: .infinity, alignment: .leading)
+                // workaround: To expand accessibility hit range
+                .background(Color("hig.charting-data.trend-detail.background"))
                 // FIXME: Remove "てん" from text in ja_JP
                 .accessibilityElement(children: .combine)
 


### PR DESCRIPTION
Closes #91 

# Changes

- SampleViewer/Assets.xcassets/Sample Colors/hig.charting-data.trend-detail.background.colorset/Contents.json
    - Add the same background color as entire view
- SampleViewer/View/ChartTrendDetailView.swift
    - Set background color to fix accessibility area

# Screenshots

<img src=https://github.com/user-attachments/assets/29ff7cec-63e9-4d21-b030-ced2264a0cf1 width=200><img src=https://github.com/user-attachments/assets/ebbaec0d-6090-4f2f-9535-6983c34c5d4f width=200>

<img src=https://github.com/user-attachments/assets/e2980bdc-5e1a-41d7-a87f-ee79d1fc07f6 width=200>