### PR TITLE
Add a sample view for share link

### DIFF
--- a/SampleViewer/Localizable.xcstrings
+++ b/SampleViewer/Localizable.xcstrings
@@ -949,6 +949,40 @@
         }
       }
     },
+    "hig.collaboration-and-sharing.link.description" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "In your SwiftUI app, you can also enable sharing by presenting a share link that opens the system-provided share sheet when people choose it."
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "SwiftUIアプリでは、選択時にシステム定義の共有シートが開く共有リンクを提示して、共有に対応することもできます。"
+          }
+        }
+      }
+    },
+    "hig.collaboration-and-sharing.link.title" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Share link"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "共有リンク"
+          }
+        }
+      }
+    },
     "hig.dark-mode.colors.dark.title" : {
       "extractionState" : "manual",
       "localizations" : {

--- a/SampleViewer/View/ShareLinkView.swift
+++ b/SampleViewer/View/ShareLinkView.swift
@@ -1,0 +1,58 @@
+import SwiftUI
+
+struct ShareLinkView: View {
+    var body: some View {
+        NavigationStack {
+            VStack {
+                Text("hig.collaboration-and-sharing.link.title")
+                    .font(.title)
+                Text("hig.collaboration-and-sharing.link.description")
+                    .font(.body)
+            }
+            .padding()
+            .toolbar {
+                ToolbarItemGroup(placement: .topBarTrailing) {
+                    Button {
+                    } label: {
+                        Image(systemName: "person.crop.circle.badge.checkmark")
+                            .foregroundStyle(Color.yellow)
+                    }
+                    .disabled(true)
+                    if let url = URL(string: "https://developer.apple.com/xcode/swiftui/") {
+                        ShareLink(item: url) {
+                            Image(systemName: "square.and.arrow.up")
+                                .foregroundStyle(Color.yellow)
+                        }
+                    }
+                    else {
+                        Button {
+                        } label: {
+                            Image(systemName: "square.and.arrow.up")
+                                .foregroundStyle(Color.yellow)
+                        }
+                        .disabled(true)
+                    }
+
+                    Button {
+                    } label: {
+                        Image(systemName: "ellipsis.circle")
+                            .foregroundStyle(Color.yellow)
+                    }
+                    .disabled(true)
+                }
+            }
+        }
+    }
+}
+
+// MARK: - Xcode Preview
+
+#Preview("ShareLinkView(locale=enUS)") {
+    ShareLinkView()
+        .environment(\.locale, .enUS)
+}
+
+#Preview("ShareLinkView(locale=jaJP)") {
+    ShareLinkView()
+        .environment(\.locale, .jaJP)
+}


### PR DESCRIPTION
Closes #75 

# Changes

- SampleViewer/Localizable.xcstrings
    - Add description texts
- SampleViewer/View/ShareLinkView.swift
    - Add a sample view

# Screenshots

|enUS|jaJP|
|---|---|
|<img src=https://github.com/user-attachments/assets/efc7a095-c2a5-4110-b356-2527249b2eb0 width=200>|<img src=https://github.com/user-attachments/assets/a87deabd-2fd6-4c28-bc3d-85b06cced2be width=200>|