### PR TITLE
Add a sample view to try drag & drop

### DIFF
--- a/SampleViewer/Localizable.xcstrings
+++ b/SampleViewer/Localizable.xcstrings
@@ -1119,6 +1119,74 @@
         }
       }
     },
+    "hig.drag-and-drop.accessibility.description" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Sometimes, drag-and-drop operations are inconvenient or impossible for people to perform, so it’s important to provide other ways to do the same things. For example, you can include menu commands that people can use to copy an item and move it to another location."
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "状況によっては、ドラッグ＆ドロップ操作がかえってユーザにとって不便だったり不可能だったりします。同じ処理を実行できる別の方法を提供することは重要です。例えば、項目をコピーして別の場所に移動できるメニューコマンドを用意できます。"
+          }
+        }
+      }
+    },
+    "hig.drag-and-drop.accessibility.drop.description" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Drop here."
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "ここにドロップする。"
+          }
+        }
+      }
+    },
+    "hig.drag-and-drop.accessibility.field.placeholder" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "This is a draggable text field."
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "ドラッグ可能なテキストフィールド。"
+          }
+        }
+      }
+    },
+    "hig.drag-and-drop.accessibility.title" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Alternative ways to accomplish drag-and-drop actions"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "ドラッグ＆ドロップと同じ処理を実行できる代替手段"
+          }
+        }
+      }
+    },
     "hig.materials.ios.description" : {
       "extractionState" : "manual",
       "localizations" : {

--- a/SampleViewer/View/AccessibleDragAndDropView.swift
+++ b/SampleViewer/View/AccessibleDragAndDropView.swift
@@ -1,0 +1,61 @@
+import SwiftUI
+
+struct AccessibleDragAndDropView: View {
+    @State
+    private var droppedString: String?
+
+    @State
+    private var inputtedString = ""
+
+    var body: some View {
+        VStack {
+            Text("hig.drag-and-drop.accessibility.title")
+                .font(.title)
+            Text("hig.drag-and-drop.accessibility.description")
+                .font(.body)
+        }
+        .padding()
+
+        // TODO: Support VoiceOver
+        VStack {
+            TextField("hig.drag-and-drop.accessibility.field.placeholder", text: $inputtedString)
+            .textFieldStyle(.roundedBorder)
+            .padding()
+            .draggable(inputtedString) {
+                Text(inputtedString)
+            }
+
+            dropDestinationView()
+            .frame(maxWidth: .infinity)
+            .padding()
+            .background(Color.gray)
+            .clipShape(RoundedRectangle(cornerRadius: 10))
+            .dropDestination(for: String.self) { items, location in
+                droppedString = items.first
+                return true
+            }
+        }
+        .padding()
+    }
+
+    private func dropDestinationView() -> Text {
+        if let droppedString {
+            Text(droppedString)
+        }
+        else {
+            Text("hig.drag-and-drop.accessibility.drop.description")
+        }
+    }
+}
+
+// MARK: - Xcode Previews
+
+#Preview("AccessibleDragAndDropView(locale=enUS)") {
+    AccessibleDragAndDropView()
+        .environment(\.locale, .enUS)
+}
+
+#Preview("AccessibleDragAndDropView(locale=jaJP)") {
+    AccessibleDragAndDropView()
+        .environment(\.locale, .jaJP)
+}


### PR DESCRIPTION
Closes #102 

# Changes

- SampleViewer/Localizable.xcstrings
    - Add description texts
- SampleViewer/View/AccessibleDragAndDropView.swift
    - Add a sample view that hasn't supported VoiceOver yet 

# Screenshots

|enUS|jaJP|
|---|---|
|<img src=https://github.com/user-attachments/assets/5b29d253-d551-49fc-ae2f-606da14340dd width=200>|<img src=https://github.com/user-attachments/assets/d668367f-505f-484f-a55a-d69b5f3885e9 width=200>|

<img src=https://github.com/user-attachments/assets/44616464-840d-43eb-b2b7-6ae329f09694 width=200><img src=https://github.com/user-attachments/assets/9c4aa680-2a87-4600-b5bd-9e4509648fa1 width=200>
