### PR TITLE
Rename `midnightOfToday(from:)` to `midnight(from:)`

### DIFF
--- a/Package/Sources/Localization/Calendar.swift
+++ b/Package/Sources/Localization/Calendar.swift
@@ -3,7 +3,7 @@ import Foundation
 extension Calendar {
     /// Midnight of today.
     /// - Returns: A new `Date`, or `nil` if fails to calculate.
-    public func midnightOfToday(
+    public func midnight(
         from date: Date
     ) -> Date? {
         return self.date(from: dateComponents([.year, .month, .day], from: date))
@@ -26,7 +26,7 @@ extension Calendar {
     public func midnightOfFirstDayOfThisWeek(
         from date: Date
     ) -> Date? {
-        var candidateDate = self.midnightOfToday(from: date)
+        var candidateDate = self.midnight(from: date)
 
         while true {
             guard let midnight = candidateDate else {

--- a/Package/Tests/LocalizationTests/MidnightTest.swift
+++ b/Package/Tests/LocalizationTests/MidnightTest.swift
@@ -2,7 +2,7 @@ import Foundation
 import Testing
 @testable import Localization
 
-struct MidnightOfTodayTest {
+struct MidnightTest {
     @Test(
         arguments: zip(
             [1735657200/*2025-01-01T00:00:00+09:00*/, 1735698153/*2025-01-01T11:22:33+09:00*/],
@@ -14,7 +14,7 @@ struct MidnightOfTodayTest {
         calendar.locale = .jaJP
         calendar.timeZone = .tokyo
 
-        let actualDate = calendar.midnightOfToday(from: Date(timeIntervalSince1970: baseUNIXTime))
+        let actualDate = calendar.midnight(from: Date(timeIntervalSince1970: baseUNIXTime))
         let expectedDate = Date(timeIntervalSince1970: expectedUNIXTime)
         #expect(actualDate == expectedDate)
     }
@@ -30,7 +30,7 @@ struct MidnightOfTodayTest {
         calendar.locale = .enUS
         calendar.timeZone = .losAngeles
 
-        let actualDate = calendar.midnightOfToday(from: Date(timeIntervalSince1970: baseUNIXTime))
+        let actualDate = calendar.midnight(from: Date(timeIntervalSince1970: baseUNIXTime))
         let expectedDate = Date(timeIntervalSince1970: expectedUNIXTime)
         #expect(actualDate == expectedDate)
     }


### PR DESCRIPTION
Closes #112 

# Changes

- Package/Sources/Localization/Calendar.swift, Package/Tests/LocalizationTests/MidnightTest.swift
    - Rename