### PR TITLE
Add a sample view for paragraph in RTL layout

### DIFF
--- a/SampleViewer/Localizable.xcstrings
+++ b/SampleViewer/Localizable.xcstrings
@@ -1595,6 +1595,57 @@
         }
       }
     },
+    "hig.right-to-left.paragraph.description" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "To improve readability, continue aligning one- and two-line text blocks to match the reading direction of the current context, but align a paragraph to match its language."
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "読みやすくするため、1行または2行のテキストブロックは引き続き現在のコンテキストでの読む方向に合わせて配置しますが、段落の場合はその言語に合わせて配置します。"
+          }
+        }
+      }
+    },
+    "hig.right-to-left.paragraph.section.uikit" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "UIKit"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "UIKit"
+          }
+        }
+      }
+    },
+    "hig.right-to-left.paragraph.title" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Alignment of a paragraph"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "段落の配置"
+          }
+        }
+      }
+    },
     "hig.right-to-left.rating.description" : {
       "extractionState" : "manual",
       "localizations" : {

--- a/SampleViewer/View/RTLParagraphView.swift
+++ b/SampleViewer/View/RTLParagraphView.swift
@@ -1,0 +1,97 @@
+import SwiftUI
+
+struct RTLParagraphView: View {
+
+    private let englishText = "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.\n"
+
+    // TODO: Use a correct Arabic sample text
+    private let arabicText = "أبجد هوز حطي كلمن سعفص قرشت ثخذ ضظغ أبجد هوز حطي كلمن سعفص قرشت ثخذ ضظغ أبجد هوز حطي كلمن سعفص قرشت ثخذ ضظغ أبجد هوز حطي كلمن سعفص قرشت ثخذ ضظغ أبجد هوز حطي كلمن سعفص قرشت ثخذ ضظغ\n"
+
+    var body: some View {
+        VStack {
+            Text("hig.right-to-left.paragraph.title")
+                .font(.title)
+            Text("hig.right-to-left.paragraph.description")
+                .font(.body)
+        }
+        .padding()
+
+        GroupBox(
+            label: Label(
+                "hig.right-to-left.paragraph.section.uikit",
+                systemImage: "square.stack.3d.up"
+            )
+        ) {
+            AttributedLabel(
+                attributedText:
+                    attributedString(from: englishText, alignment: .left)
+                + attributedString(from: arabicText, alignment: .right)
+            )
+        }
+        .padding()
+
+        // TODO: Use `ScrollView`
+        // TODO: Use SwiftUI
+    }
+
+    private func attributedString(from text: String, alignment: NSTextAlignment) -> NSAttributedString {
+        let paragraphStyle = NSMutableParagraphStyle()
+        paragraphStyle.alignment = alignment
+        return NSAttributedString(string: text, attributes: [.paragraphStyle: paragraphStyle])
+    }
+}
+
+private func +(lhs: NSAttributedString, rhs: NSAttributedString) -> NSAttributedString {
+    let base = NSMutableAttributedString(attributedString: lhs)
+    base.append(rhs)
+    return base
+}
+
+private struct AttributedLabel: UIViewRepresentable {
+    private var attributedText: NSAttributedString
+
+    init(attributedText: NSAttributedString) {
+        self.attributedText = attributedText
+    }
+
+    func makeUIView(context: Context) -> UIView {
+        let view = UIView()
+        let label = UILabel()
+        label.attributedText = attributedText
+        label.numberOfLines = 0
+        view.addSubview(label)
+        label.translatesAutoresizingMaskIntoConstraints = false
+
+        NSLayoutConstraint.activate([
+            label.leadingAnchor.constraint(equalTo: view.leadingAnchor),
+            label.trailingAnchor.constraint(equalTo: view.trailingAnchor),
+            label.topAnchor.constraint(equalTo: view.topAnchor),
+            label.bottomAnchor.constraint(equalTo: view.bottomAnchor)
+        ])
+        return view
+    }
+    
+    func updateUIView(_ uiView: UIView, context: Context) {
+        // TODO: Calculate height
+    }
+}
+
+// MARK: - Xcode Preview
+
+#Preview("RTLParagraphView(locale=enUS,layoutDirection=leftToRight)") {
+    RTLParagraphView()
+        .environment(\.locale, .enUS)
+        .environment(\.layoutDirection, .leftToRight)
+}
+
+#Preview("RTLParagraphView(locale=jaJP,layoutDirection=leftToRight)") {
+    RTLParagraphView()
+        .environment(\.locale, .jaJP)
+        .environment(\.layoutDirection, .leftToRight)
+}
+
+#Preview("RTLParagraphView(locale=enUS,layoutDirection=rightToLeft)") {
+    RTLParagraphView()
+        .environment(\.locale, .enUS)
+        .environment(\.layoutDirection, .rightToLeft)
+}


### PR DESCRIPTION
Closes #115 

# Changes

- SampleViewer/Localizable.xcstrings
    - Add description text
- SampleViewer/View/RTLParagraphView.swift
    - Add sample view

# Screenshots

||enUS|jaJP|
|---|---|---|
|LTR|<img src=https://github.com/user-attachments/assets/3504dd43-25db-488d-9ee3-9b08cf290ca0 width=200>|<img src=https://github.com/user-attachments/assets/05bc48f3-84d8-4cbd-bfb6-7b79a6e77ca9 width=200>|
|RTL|<img src=https://github.com/user-attachments/assets/d1164df8-53b5-4445-8d21-227d6e178bba width=200>||
