### PR TITLE
Add a sample for system background colors

### DIFF
--- a/SampleViewer/Environment/UserInterfaceLevel.swift
+++ b/SampleViewer/Environment/UserInterfaceLevel.swift
@@ -1,0 +1,22 @@
+import SwiftUI
+import UIKit
+
+struct UserInterfaceLevel {
+}
+
+extension UserInterfaceLevel: EnvironmentKey {
+    static var defaultValue: UIUserInterfaceLevel {
+        return UITraitCollection.current.userInterfaceLevel
+    }
+}
+
+extension EnvironmentValues {
+    var userInterfaceLevel: UIUserInterfaceLevel {
+        get {
+            self[UserInterfaceLevel.self]
+        }
+        set {
+            self[UserInterfaceLevel.self] = newValue
+        }
+    }
+}

--- a/SampleViewer/Localizable.xcstrings
+++ b/SampleViewer/Localizable.xcstrings
@@ -1119,6 +1119,105 @@
         }
       }
     },
+    "hig.dark-mode.system.base.title" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Base"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "ベース"
+          }
+        }
+      }
+    },
+    "hig.dark-mode.system.button.title" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Open"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "開く"
+          }
+        }
+      }
+    },
+    "hig.dark-mode.system.description" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Dark Mode is dynamic, which means that the background color automatically changes from base to elevated when an interface is in the foreground, such as a popover or modal sheet. The system also uses the elevated background color to provide visual separation between apps in a multitasking environment and between windows in a multiple-window context."
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "ダークモードはダイナミックです。つまり、ポップオーバーやモーダルシートなどのようにインターフェイスがフォアグラウンドにある場合には、バックグラウンドカラーがベースから高階調に自動的に変化します。また、マルチタスク環境のアプリを視覚的に区別したり、複数ウインドウ環境でウインドウを区別したりする場合にも、高階調のバックグラウンドカラーが使用されます。"
+          }
+        }
+      }
+    },
+    "hig.dark-mode.system.elevated.title" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Elevated"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "高階調"
+          }
+        }
+      }
+    },
+    "hig.dark-mode.system.light.title" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Light"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "ライト"
+          }
+        }
+      }
+    },
+    "hig.dark-mode.system.title" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "System background colors"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "システムのバックグラウンドカラー"
+          }
+        }
+      }
+    },
     "hig.drag-and-drop.accessibility.description" : {
       "extractionState" : "manual",
       "localizations" : {

--- a/SampleViewer/View/SystemBackgroundColorView.swift
+++ b/SampleViewer/View/SystemBackgroundColorView.swift
@@ -1,0 +1,94 @@
+import SwiftUI
+
+struct SystemBackgroundColorView: View {
+    @Environment(\.userInterfaceLevel)
+    private var userInterfaceLevel: UIUserInterfaceLevel
+
+    @State
+    private var isPresented = false
+
+    private let appearanceBoxes = [
+        AppearanceBox(
+            id: UUID(),
+            titleKey: { _ in "hig.dark-mode.system.light.title" },
+            colorScheme: .light
+        ),
+        AppearanceBox(
+            id: UUID(),
+            titleKey: {
+                $0 == .elevated
+                    ? "hig.dark-mode.system.elevated.title"
+                    : "hig.dark-mode.system.base.title"
+            },
+            colorScheme: .dark
+        ),
+    ]
+
+    var body: some View {
+        VStack {
+            Text("hig.dark-mode.system.title")
+                .font(.title)
+            Text("hig.dark-mode.system.description")
+                .font(.body)
+        }
+        .padding()
+
+        Button {
+            isPresented.toggle()
+        } label: {
+            Text("hig.dark-mode.system.button.title")
+        }
+        .sheet(isPresented: $isPresented) {
+            SystemBackgroundColorView()
+        }
+
+        VStack {
+            ForEach(appearanceBoxes) { appearanceBox in
+                GroupBox(appearanceBox.titleKey(userInterfaceLevel)) {
+                    VStack {
+                        Text(verbatim: "label")
+                            .foregroundStyle(Color(uiColor: UIColor.label))
+                        Text(verbatim: "secondaryLabel")
+                            .foregroundStyle(Color(uiColor: UIColor.secondaryLabel))
+                        Text(verbatim: "tertiaryLabel")
+                            .foregroundStyle(Color(uiColor: UIColor.tertiaryLabel))
+                        Text(verbatim: "quaternaryLabel")
+                            .foregroundStyle(Color(uiColor: UIColor.quaternaryLabel))
+                    }
+                    .padding()
+                }
+                .backgroundStyle(Color(uiColor: UIColor.systemBackground))
+                .environment(\.colorScheme, appearanceBox.colorScheme)
+            }
+        }
+        .padding()
+    }
+}
+
+// MARK: - AppearanceBox
+
+private struct AppearanceBox: Identifiable {
+    var id: UUID
+    var titleKey: (UIUserInterfaceLevel) -> LocalizedStringKey
+    var colorScheme: ColorScheme
+}
+
+// MARK: - Xcode Preview
+
+#Preview("SystemBackgroundColorView(locale=enUS,colorScheme=light)") {
+    SystemBackgroundColorView()
+        .environment(\.locale, .enUS)
+        .environment(\.colorScheme, .light)
+}
+
+#Preview("SystemBackgroundColorView(locale=enUS,colorScheme=dark)") {
+    SystemBackgroundColorView()
+        .environment(\.locale, .enUS)
+        .environment(\.colorScheme, .dark)
+}
+
+#Preview("SystemBackgroundColorView(locale=jaJP,colorScheme=light)") {
+    SystemBackgroundColorView()
+        .environment(\.locale, .jaJP)
+        .environment(\.colorScheme, .light)
+}


### PR DESCRIPTION
Closes #18 

# Changes

- SampleViewer/Environment/UserInterfaceLevel.swift
    - Extension to get current UI level
- SampleViewer/Localizable.xcstrings
    - Add description texts
- SampleViewer/View/SystemBackgroundColorView.swift
    - Add the sample view

# Screenshots

||enUS|jaJP|
|---|---|---|
|light|<img src=https://github.com/user-attachments/assets/153578e3-a8bf-4ef9-92ce-bea6f9db5e6b width=200><img src=https://github.com/user-attachments/assets/4f621c7e-0a20-4b3e-8f6b-1485fd75d50c width=200>||
|dark|<img src=https://github.com/user-attachments/assets/3a919fd2-a047-4a86-900c-741cf1ea468f width=200><img src=https://github.com/user-attachments/assets/9a47b2bc-dee4-4d14-8312-e53832b2efd4 width=200>|<img src=https://github.com/user-attachments/assets/85e1882f-fb34-42fd-b2c7-7f23ee0ecb94 width=200>|
