### PR TITLE
Add a sample view of secure text field view

### DIFF
--- a/SampleViewer/Localizable.xcstrings
+++ b/SampleViewer/Localizable.xcstrings
@@ -1388,6 +1388,57 @@
         }
       }
     },
+    "hig.entering-data.secure-field.description" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "If your app or game needs sensitive data, use a field that obscures people’s input as they enter it, typically by displaying a small filled circle symbol for each character."
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "機密データを必要とするアプリやゲームでは、ユーザの入力内容が表示されないフィールドを使用します（通常、入力文字の代わりに小さい「●」が表示される）。"
+          }
+        }
+      }
+    },
+    "hig.entering-data.secure-field.password.label" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Password"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "パスワード"
+          }
+        }
+      }
+    },
+    "hig.entering-data.secure-field.title" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "A secure text-entry field"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "セキュリティ保護されたテキスト入力フィールド"
+          }
+        }
+      }
+    },
     "hig.materials.ios.description" : {
       "extractionState" : "manual",
       "localizations" : {

--- a/SampleViewer/View/SecureTextFieldView.swift
+++ b/SampleViewer/View/SecureTextFieldView.swift
@@ -1,0 +1,40 @@
+import SwiftUI
+
+struct SecureTextFieldView: View {
+    @Binding
+    private var secureFieldText: String
+
+    init() {
+        _secureFieldText = .constant("")
+    }
+
+    var body: some View {
+        VStack {
+            Text("hig.entering-data.secure-field.title")
+                .font(.title)
+            Text("hig.entering-data.secure-field.description")
+                .font(.body)
+        }
+        .padding()
+
+        VStack {
+            SecureField(
+                "hig.entering-data.secure-field.password.label",
+                text: $secureFieldText
+            )
+        }
+        .padding()
+    }
+}
+
+// MARK: - Xcode Preview
+
+#Preview("SecureTextFieldView(locale=enUS)") {
+    SecureTextFieldView()
+        .environment(\.locale, .enUS)
+}
+
+#Preview("SecureTextFieldView(locale=jaJP)") {
+    SecureTextFieldView()
+        .environment(\.locale, .jaJP)
+}


### PR DESCRIPTION
Closes #138

# Changes

- SampleViewer/Localizable.xcstrings
    - Add description texts
- SampleViewer/View/SecureTextFieldView.swift
    - Add the sample view

# Screenshots

|enUS|jaJP|
|---|---|
|<img src=https://github.com/user-attachments/assets/b3251b62-8e3c-4671-9cf4-62becbbf0952 width=150><img src=https://github.com/user-attachments/assets/d87ecf2a-da43-44c2-9952-d97a3a89e73c width=150>|<img src=https://github.com/user-attachments/assets/b8955683-4461-4af8-b004-249f35765d5b width=150><img src=https://github.com/user-attachments/assets/adaf286b-857b-42b8-ae25-712a4d6571e8 width=150>|