### PR TITLE
Add a sample view for text field validation

### DIFF
--- a/SampleViewer/Localizable.xcstrings
+++ b/SampleViewer/Localizable.xcstrings
@@ -1541,6 +1541,57 @@
         }
       }
     },
+    "hig.entering-data.validation.description" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "People can get frustrated when they have to go back and correct mistakes after filling out a lengthy form. When you verify values as soon as people enter them — and provide feedback as soon as you detect a problem — you give them the opportunity to correct errors right away."
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "長いフォームに入力したあとで、戻って間違いを修正しなければならないという流れは、ユーザのイライラの原因になります。ユーザが入力した直後にその値を確認し、問題を検出したらすぐにフィードバックを提示するようにすれば、その場で間違いを訂正できます。"
+          }
+        }
+      }
+    },
+    "hig.entering-data.validation.price.label" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Stock price"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "株価"
+          }
+        }
+      }
+    },
+    "hig.entering-data.validation.title" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Dynamically validation"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "動的な検証"
+          }
+        }
+      }
+    },
     "hig.materials.ios.description" : {
       "extractionState" : "manual",
       "localizations" : {

--- a/SampleViewer/View/FieldValueValidationView.swift
+++ b/SampleViewer/View/FieldValueValidationView.swift
@@ -1,0 +1,41 @@
+import SwiftUI
+
+struct FieldValueValidationView: View {
+    @State
+    private var price = 0.0
+
+    var body: some View {
+        VStack {
+            Text("hig.entering-data.validation.title")
+                .font(.title)
+            Text("hig.entering-data.validation.description")
+                .font(.body)
+        }
+        .padding()
+
+        Form {
+            Section {
+                TextField(
+                    "hig.entering-data.validation.price.label",
+                    value: $price,
+                    format: .number.precision(.fractionLength(2))
+                )
+                .keyboardType(.decimalPad)
+            } footer: {
+                Text(price, format: .currency(code: "JPY").precision(.fractionLength(2)))
+            }
+        }
+    }
+}
+
+// MARK: - Xcode Preview
+
+#Preview("FieldValueValidationView(locale=enUS)") {
+    FieldValueValidationView()
+        .environment(\.locale, .enUS)
+}
+
+#Preview("FieldValueValidationView(locale=jaJP)") {
+    FieldValueValidationView()
+        .environment(\.locale, .jaJP)
+}


### PR DESCRIPTION
Closes #142 

# Changes

- SampleViewer/Localizable.xcstrings
    - Add description texts
- SampleViewer/View/FieldValueValidationView.swift
    - Add the sample view

# Screenshots

|enUS|jaJP|
|---|---|
|<img src=https://github.com/user-attachments/assets/1651efb2-0ad8-4cd5-b9a3-995edd897f93 width=150><img src=https://github.com/user-attachments/assets/d030b487-e61b-4bcb-a83f-05c7d6018ea4 width=150>|<img src=https://github.com/user-attachments/assets/06977ab5-da08-4a72-b243-f7d71163dfe3 width=150><img src=https://github.com/user-attachments/assets/553cc925-11fa-47d8-8f73-0f69d69370e9 width=150>|