### PR TITLE
Add a sample view for Next button with form

### DIFF
--- a/SampleViewer/Localizable.xcstrings
+++ b/SampleViewer/Localizable.xcstrings
@@ -1490,6 +1490,74 @@
         }
       }
     },
+    "hig.entering-data.next.button.label" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Next"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "次へ"
+          }
+        }
+      }
+    },
+    "hig.entering-data.next.description" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "When data entry is necessary, make sure people understand that they must provide the required data before they can proceed."
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "データ入力が必要な場合は、必須データを提供するまで次に進めないことがユーザに分かるようにする。"
+          }
+        }
+      }
+    },
+    "hig.entering-data.next.field.label" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Name"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "名前"
+          }
+        }
+      }
+    },
+    "hig.entering-data.next.title" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Required data"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "必須データ"
+          }
+        }
+      }
+    },
     "hig.entering-data.secure-field.description" : {
       "extractionState" : "manual",
       "localizations" : {

--- a/SampleViewer/View/NextButtonView.swift
+++ b/SampleViewer/View/NextButtonView.swift
@@ -1,0 +1,39 @@
+import SwiftUI
+
+struct NextButtonView: View {
+    @State
+    private var name = ""
+
+    var body: some View {
+        VStack {
+            Text("hig.entering-data.next.title")
+                .font(.title)
+            Text("hig.entering-data.next.description")
+                .font(.body)
+        }
+        .padding()
+
+        VStack {
+                TextField("hig.entering-data.next.field.label", text: $name)
+                Button {
+                } label: {
+                    Text("hig.entering-data.next.button.label")
+                }
+                .disabled(name.isEmpty)
+                .buttonStyle(.bordered)
+        }
+        .padding()
+    }
+}
+
+// MARK: - Xcode Preview
+
+#Preview("NextButtonView(locale=enUS)") {
+    NextButtonView()
+        .environment(\.locale, .enUS)
+}
+
+#Preview("NextButtonView(locale=jaJP)") {
+    NextButtonView()
+        .environment(\.locale, .jaJP)
+}


### PR DESCRIPTION
Closes #144 

# Changes

- SampleViewer/Localizable.xcstrings
    - Add description texts
- SampleViewer/View/NextButtonView.swift
    - Add the sample view

# Screenshots

|enUS|jaJP|
|---|---|
|<img src=https://github.com/user-attachments/assets/9bac3077-b0f1-47ae-b47d-ee37b15da093 width=150><img src=https://github.com/user-attachments/assets/d3d313e6-6f56-4d75-8d0b-e371fbc21ca6 width=150>|<img src=https://github.com/user-attachments/assets/869cca19-bc99-4b34-9ef6-c1f85aaabb4e width=150><img src=https://github.com/user-attachments/assets/c3477bc5-8e69-4665-9bf7-ad6fd365ef35 width=150>|