### PR TITLE
Add title and description about Dynamic Type

### DIFF
--- a/SampleViewer/Localizable.xcstrings
+++ b/SampleViewer/Localizable.xcstrings
@@ -290,6 +290,40 @@
         }
       }
     },
+    "hig.accessibility.dynamic-type.description" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Dynamic Type lets people pick the font size that works for them. Verify that your design can scale and that both text and glyphs are legible at all font sizes."
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Dynamic Typeに対応すると、ユーザが好みのフォントサイズを選択できます。デザインを適切に拡大/縮小できるか、テキストとグリフの両方がどのフォントサイズでも判読できるかを検証してください。"
+          }
+        }
+      }
+    },
+    "hig.accessibility.dynamic-type.title" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Dynamic Type"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Dynamic Type"
+          }
+        }
+      }
+    },
     "hig.accessibility.gestures.alternative.description" : {
       "extractionState" : "manual",
       "localizations" : {

--- a/SampleViewer/View/DynamicTypeView.swift
+++ b/SampleViewer/View/DynamicTypeView.swift
@@ -3,7 +3,19 @@ import SwiftUI
 // TODO: Set background color, drop shadow
 // TODO: Set title of back button
 struct DynamicTypeView: View {
+    @Environment(\.dynamicTypeSize)
+    private var dynamicTypeSize
+
     var body: some View {
+        VStack {
+            Text("hig.accessibility.dynamic-type.title")
+                .font(.title)
+            if !dynamicTypeSize.isAccessibilitySize {
+                Text("hig.accessibility.dynamic-type.description")
+                    .font(.body)
+            }
+        }
+        .padding(.horizontal)
         NavigationStack {
             ScrollView {
                 VStack {


### PR DESCRIPTION
Closes #47 

# Changes

- SampleViewer/Localizable.xcstrings
    - Add description texts
- SampleViewer/View/DynamicTypeView.swift
    - Add description texts
        - Set padding only to leading and trailing to save space
        - Hide description for when accessibility font size is enable to save space

# Screenshots

||enUS|jaJP|
|---|---|---|
|normal|<img src=https://github.com/user-attachments/assets/3bd7744f-7b9f-497b-8eb5-f6f614649e3d width=200>|<img src=https://github.com/user-attachments/assets/b4d9d40c-44d8-4b71-ae3e-fcb4ae77378b width=200>|
|accessibility1|<img src=https://github.com/user-attachments/assets/791fd3b3-cbf9-46e9-90c1-6e24dafc3dfb width=200>||