### PR TITLE
Configure background of the sample view for Dynamic Type

### DIFF
--- a/SampleViewer/Assets.xcassets/Sample Colors/hig.accessibility.dynamic-type.mail.background.colorset/Contents.json
+++ b/SampleViewer/Assets.xcassets/Sample Colors/hig.accessibility.dynamic-type.mail.background.colorset/Contents.json
@@ -1,0 +1,38 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0xFF",
+          "green" : "0xFF",
+          "red" : "0xFE"
+        }
+      },
+      "idiom" : "universal"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "dark"
+        }
+      ],
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0x1E",
+          "green" : "0x1C",
+          "red" : "0x1C"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/SampleViewer/View/DynamicTypeView.swift
+++ b/SampleViewer/View/DynamicTypeView.swift
@@ -174,25 +174,27 @@ private struct AccessibleHStack<Content>: View where Content: View {
 
 // MARK: - Xcode Preview
 
-#Preview("DynamicTypeView(locale=enUS)") {
+#Preview("DynamicTypeView(locale=enUS,timeZone=losAngeles)") {
     DynamicTypeView()
         .environment(\.locale, .enUS)
         .environment(\.timeZone, .losAngeles)
 }
 
-#Preview("DynamicTypeView(locale=jaJP)") {
+#Preview("DynamicTypeView(locale=jaJP,timeZone=jaJP)") {
     DynamicTypeView()
         .environment(\.locale, .jaJP)
         .environment(\.timeZone, .tokyo)
 }
 
-#Preview("DynamicTypeView(dynamicTypeSize=xxxLarge)") {
+#Preview("DynamicTypeView(locale=enUS,dynamicTypeSize=xxxLarge)") {
     DynamicTypeView()
+        .environment(\.locale, .enUS)
         .environment(\.dynamicTypeSize, .xxxLarge)
 }
 
-#Preview("DynamicTypeView(dynamicTypeSize=accessibility5)") {
+#Preview("DynamicTypeView(locale=enUS,dynamicTypeSize=accessibility5)") {
     DynamicTypeView()
+        .environment(\.locale, .enUS)
         .environment(\.dynamicTypeSize, .accessibility5)
 }
 

--- a/SampleViewer/View/DynamicTypeView.swift
+++ b/SampleViewer/View/DynamicTypeView.swift
@@ -22,6 +22,7 @@ struct DynamicTypeView: View {
                     .padding(.top)
                     .padding(.horizontal)
                 Divider()
+                    .padding(.leading)
                 ScrollView {
                     // TODO: Show a sample message
                     Text("Hello, World!")

--- a/SampleViewer/View/DynamicTypeView.swift
+++ b/SampleViewer/View/DynamicTypeView.swift
@@ -25,7 +25,7 @@ struct DynamicTypeView: View {
                     .padding(.leading)
                 ScrollView {
                     // TODO: Show a sample message
-                    Text("Hello, World!")
+                    Text(verbatim: "Hello, World!")
                 }
             }
             .background(Color("hig.accessibility.dynamic-type.mail.background"))

--- a/SampleViewer/View/DynamicTypeView.swift
+++ b/SampleViewer/View/DynamicTypeView.swift
@@ -1,6 +1,6 @@
 import SwiftUI
 
-// TODO: Set background color, drop shadow
+// TODO: Set drop shadow
 // TODO: Set title of back button
 struct DynamicTypeView: View {
     @Environment(\.dynamicTypeSize)
@@ -17,15 +17,17 @@ struct DynamicTypeView: View {
         }
         .padding(.horizontal)
         NavigationStack {
-            ScrollView {
-                VStack {
-                    SampleHeaderView()
-                    Divider()
+            VStack {
+                SampleHeaderView()
+                    .padding(.top)
+                    .padding(.horizontal)
+                Divider()
+                ScrollView {
                     // TODO: Show a sample message
                     Text("Hello, World!")
                 }
-                .padding()
             }
+            .background(Color("hig.accessibility.dynamic-type.mail.background"))
             .toolbar {
                 ToolbarItemGroup(placement: .topBarTrailing) {
                     Button {
@@ -59,6 +61,10 @@ struct DynamicTypeView: View {
                     }
                 }
             }
+            .toolbarBackgroundVisibility(.visible, for: .navigationBar)
+            .toolbarBackground(Color(uiColor: UIColor.systemBackground), for: .navigationBar)
+            .toolbarBackgroundVisibility(.visible, for: .bottomBar)
+            .toolbarBackground(Color(uiColor: UIColor.systemBackground), for: .tabBar)
         }
     }
 }
@@ -196,6 +202,12 @@ private struct AccessibleHStack<Content>: View where Content: View {
     DynamicTypeView()
         .environment(\.locale, .enUS)
         .environment(\.dynamicTypeSize, .accessibility5)
+}
+
+#Preview("DynamicTypeView(locale=enUS,colorScheme=dark)") {
+    DynamicTypeView()
+        .environment(\.locale, .enUS)
+        .environment(\.colorScheme, .dark)
 }
 
 #Preview("SampleHeaderView") {

--- a/SampleViewer/View/DynamicTypeView.swift
+++ b/SampleViewer/View/DynamicTypeView.swift
@@ -116,7 +116,6 @@ private struct SampleHeaderView: View {
                 Image(systemName: "paperclip")
                     .foregroundStyle(.gray)
             }
-
         }
     }
 }


### PR DESCRIPTION
Closes #42 

# Changes

- SampleViewer/Assets.xcassets/Sample Colors/hig.accessibility.dynamic-type.mail.background.colorset/Contents.json
    - Add a background color
- SampleViewer/View/DynamicTypeView.swift
    - (b68cfce820b10c8e6a34650f186ad85e29a78e11) Configure the background color 
    - (430a98346e0b75a94b8ae97f3e13a0c26414fd0c) Add some Xcode Previews
    - (e8c89b3fec3f5f76d93055ced43f4624001203c3) Fix padding of divider
        - The sample on [HIG](https://developer.apple.com/design/human-interface-guidelines/accessibility) doesn't have leading padding.
    - (71cc5aacd785c124e571f178c4da7a9c639a7c7e) Fix `Text` to avoid adding a new localized key automatically
    - (fbb24db7a3b27e2684d2c0a17e82ff99f6ecbc40) Refactor

# Note

Tab bar seems to have translucent background color in iOS 15 and later.
ref: [iOS 15でNavigationBarとTabBarがデフォルトで透過される](https://blog.personal-factory.com/2021/12/29/ios15-transparent-navigationbar-and-tabbar-by-default/)

# Screenshots
<img src=https://github.com/user-attachments/assets/7bdeadc3-e602-4829-b386-d7178deb32ec width=200>
<img src=https://github.com/user-attachments/assets/0e7b906d-3472-4031-93cf-cbdd4f86a0b4 width=200>