### PR TITLE
Use localized string to show temperature unit

### DIFF
--- a/SampleViewer/Localizable.xcstrings
+++ b/SampleViewer/Localizable.xcstrings
@@ -3378,6 +3378,23 @@
         }
       }
     },
+    "unit.temperature.simplified%lld" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%lld°"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%lld"
+          }
+        }
+      }
+    },
     "unit.weeks%lld" : {
       "extractionState" : "manual",
       "localizations" : {

--- a/SampleViewer/View/ChartDescriptiveTextView.swift
+++ b/SampleViewer/View/ChartDescriptiveTextView.swift
@@ -124,8 +124,7 @@ struct ChartDescriptiveTextView: View {
         case let .sunny(temperature: temperature),
              let .clearNight(temperature: temperature),
              let .windy(temperature: temperature):
-            // TODO: Use correct temperature unit
-            Text(verbatim: "\(temperature)°")
+            Text("unit.temperature.simplified\(temperature)")
         case .sunrise:
             Text("hig.charting-data.descriptive.sunrise.description")
         case .sunset:


### PR DESCRIPTION
Closes #79 

# Changes

- SampleViewer/Localizable.xcstrings
    - Add a new key to show temperature unit
- SampleViewer/View/ChartDescriptiveTextView.swift
    - Use the key

# Screenshots

|enUS|jaJP|
|---|---|
|<img src=https://github.com/user-attachments/assets/6679bdb4-2ee6-4cef-95a8-89fb1db6d0f5 width=200>|<img src=https://github.com/user-attachments/assets/3683b100-fdfe-4f8b-8e73-576da90f0be6 width=200>|